### PR TITLE
Slurm scheduler

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -70,10 +70,12 @@ ignore =
   WPS407,
   ; Found walrus operator
   WPS332,
+  ; Found protected module import: _runner
+  WPS436,
 
 per-file-ignores =
   ; all tests
-  test_*.py,tests.py,tests_*.py,*/tests/*,conftest.py:
+  test_*.py,tests.py,tests_*.py,*/tests/*, */tests/*/*,conftest.py:
   ; Use of assert detected
   S101,
   ; Found outer scope names shadowing
@@ -86,12 +88,18 @@ per-file-ignores =
   DAR101,
   ; Found too many arguments
   WPS211,
+  ; Missing docstring in public class
+  D101,
+  ; Missing docstring in public method
+  D102,
   ; Missing docstring in public function
   D103,
   ; Missing docstring in public package
   D104,
   ; Missing "Returns" in Docstring: - return
   DAR201,
+  ; Found too long name: test_ok_running_job_with_input_and_output_file
+  WPS118,
   ; all init files
   __init__.py:
   ; ignore not used imports
@@ -100,6 +108,7 @@ per-file-ignores =
   F403,
   ; Found wrong metadata variable
   WPS410,
+
 
 exclude =
   ./.cache,

--- a/bartender/_ssh_utils.py
+++ b/bartender/_ssh_utils.py
@@ -1,0 +1,33 @@
+from typing import Optional, TypedDict
+
+from asyncssh import SSHClientConnection, connect
+
+
+class SshConnectConfig(TypedDict):
+    """Configuration for ssh connection."""
+
+    hostname: str
+    port: Optional[int]
+    username: Optional[str]
+    password: Optional[str]
+
+
+async def ssh_connect(config: SshConnectConfig) -> SSHClientConnection:
+    """Connect to a host using SSH.
+
+    :param config: Configuration.
+    :return: The connection.
+    """
+    conn_vargs = {
+        "known_hosts": None,
+    }
+    if config["password"] is not None:
+        conn_vargs["agent_path"] = None
+
+    return await connect(
+        host=config["hostname"],
+        port=config["port"],
+        username=config["username"],
+        password=config["password"],
+        **conn_vargs,
+    )

--- a/bartender/_ssh_utils.py
+++ b/bartender/_ssh_utils.py
@@ -19,6 +19,7 @@ async def ssh_connect(config: SshConnectConfig) -> SSHClientConnection:
     :return: The connection.
     """
     conn_vargs = {
+        # disable server host key validation
         "known_hosts": None,
     }
     if config["password"] is not None:

--- a/bartender/filesystems/__init__.py
+++ b/bartender/filesystems/__init__.py
@@ -1,0 +1,1 @@
+"""Adaptors for different file systems."""

--- a/bartender/filesystems/abstract.py
+++ b/bartender/filesystems/abstract.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Protocol
+
+from bartender.schedulers.abstract import JobDescription
+
+
+class AbstractFileSystem(Protocol):
+    """A file system interface."""
+
+    def localize_description(
+        self,
+        description: JobDescription,
+        entry: Path,
+    ) -> JobDescription:
+        """Make given job description local to this file system.
+
+        :param description: A job description.
+        :param entry: The path to replace with the entry path of this file system.
+            For example given a file system with entry path of /remote/jobs
+            and given job_dir in job description of /local/jobs/myjobid
+            and given entry of /local/jobs
+            will return description with job dir /remote/jobs/myjobid .
+        :return: A job description local to this file system.
+        """  # noqa: DAR202
+
+    async def upload(self, src: JobDescription, target: JobDescription) -> None:
+        """Uploads job directory of source description to job directory of target.
+
+        :param src: Local directory to copy from.
+        :param target: Remote directory to copy to.
+        """
+
+    async def download(self, src: JobDescription, target: JobDescription) -> None:
+        """Download job directory of source description to job directory of target.
+
+        :param src: Remote directory to copy from.
+        :param target: Local directory to copy to.
+        """

--- a/bartender/filesystems/local.py
+++ b/bartender/filesystems/local.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from bartender.filesystems.abstract import AbstractFileSystem
+from bartender.schedulers.abstract import JobDescription
+
+
+class LocalFileSystem(AbstractFileSystem):
+    """File system operations on file system current Python process is running on."""
+
+    def localize_description(
+        self,
+        description: JobDescription,
+        entry: Path,
+    ) -> JobDescription:
+        """Make given job description local to this file system.
+
+        :param description: A job description.
+        :param entry: The path to replace with the entry path of this file system.
+            For example given a file system with entry path of /remote/jobs
+            and given job_dir in job description of /local/jobs/myjobid
+            and given entry of /local/jobs
+            will return description with job dir /remote/jobs/myjobid .
+        :return: A job description local to this file system.
+        """
+        # TODO do something with entry argument?
+        return description
+
+    async def upload(
+        self,
+        src: JobDescription,
+        target: JobDescription,
+    ) -> None:
+        """Uploads job directory of source description to job directory of target.
+
+        :param src: Local directory to copy from.
+        :param target: Remote directory to copy to.
+        """
+
+    async def download(
+        self,
+        src: JobDescription,
+        target: JobDescription,
+    ) -> None:
+        """Download job directory of source description to job directory of target.
+
+        :param src: Remote directory to copy from.
+        :param target: Local directory to copy to.
+        """

--- a/bartender/filesystems/sftp.py
+++ b/bartender/filesystems/sftp.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from typing import Optional
+
+from asyncssh import SSHClientConnection
+
+from bartender._ssh_utils import SshConnectConfig, ssh_connect
+from bartender.filesystems.abstract import AbstractFileSystem
+from bartender.schedulers.abstract import JobDescription
+
+
+class SftpFileSystem(AbstractFileSystem):
+    """Remote filesystem using SFTP protocol."""
+
+    def __init__(
+        self,
+        entry: Path,
+        config: SshConnectConfig,
+    ):
+        """Constructor.
+
+        :param entry: The entry directory. Used to localize description.
+        :param config: SSH connection configuration.
+        """
+        self.entry = entry
+        self.config = config
+        self.conn: Optional[SSHClientConnection] = None
+
+    def localize_description(
+        self,
+        description: JobDescription,
+        entry: Path,
+    ) -> JobDescription:
+        """Make given job description local to this file system.
+
+        :param description: A job description.
+        :param entry: The path to replace with the entry path of this file system.
+            For example given a file system with entry path of /remote/jobs
+            and given job_dir in job description of /local/jobs/myjobid
+            and given entry of /local/jobs
+            will return description with job dir /remote/jobs/myjobid .
+        :return: A job description local to this file system.
+        """
+        localized_desciption = description.copy()
+        localized_desciption.job_dir = self.entry / Path(
+            description.job_dir,
+        ).relative_to(entry)
+        return localized_desciption
+
+    async def upload(self, src: JobDescription, target: JobDescription) -> None:
+        """Uploads job directory of source description to job directory of target.
+
+        :param src: Local directory to copy from.
+        :param target: Remote directory to copy to.
+        """
+        if self.conn is None:
+            self.conn = await ssh_connect(self.config)
+        async with self.conn.start_sftp_client() as sftp:
+            localpaths = [str(src.job_dir)]
+            remotepath = str(target.job_dir)
+            await sftp.put(localpaths, remotepath, recurse=True)
+
+    async def download(self, src: JobDescription, target: JobDescription) -> None:
+        """Download job directory of source description to job directory of target.
+
+        :param src: Remote directory to copy from.
+        :param target: Local directory to copy to.
+        """
+        if self.conn is None:
+            self.conn = await ssh_connect(self.config)
+        async with self.conn.start_sftp_client() as sftp:
+            # target.job_dir.parent is used
+            # so /remote/jobid/output becomes /local/jobid/output,
+            # otherwise it would be /local/jobid/jobid/output
+            localpaths = [str(src.job_dir)]
+            remotepath = str(target.job_dir.parent)
+            await sftp.get(localpaths, remotepath, recurse=True)
+
+    def close(self) -> None:
+        """Close SSH connection."""
+        if self.conn:
+            self.conn.close()

--- a/bartender/schedulers/runner.py
+++ b/bartender/schedulers/runner.py
@@ -1,0 +1,135 @@
+from asyncio import create_subprocess_exec
+from asyncio.subprocess import PIPE
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+from asyncssh import SSHClientConnection
+
+from bartender._ssh_utils import SshConnectConfig, ssh_connect
+
+
+class CommandRunner(Protocol):
+    """Protocol for running a command."""
+
+    async def run(
+        self,
+        command: str,
+        args: list[str],
+        stdin: Optional[str] = None,
+        cwd: Optional[Path] = None,
+    ) -> tuple[int, str, str]:
+        """Run command.
+
+        :param command: Command to execute. Command can not contain spaces.
+        :param args: List of arguments for command.
+            Argument containing spaces should be wrapped in quotes.
+        :param stdin: Input for command.
+        :param cwd: In which directory the command should be run.
+        :return: Tuple with return code, stdout and stderr.
+        """  # noqa: DAR202
+
+    def close(self) -> None:
+        """Close any connections runner has."""
+
+
+class LocalCommandRunner(CommandRunner):
+    """Runs command on system where current Python process is running."""
+
+    async def run(
+        self,
+        command: str,
+        args: list[str],
+        stdin: Optional[str] = None,
+        cwd: Optional[Path] = None,
+    ) -> tuple[int, str, str]:
+        """Run command.
+
+        :param command: Command to execute. Command can not contain spaces.
+        :param args: List of arguments for command.
+            Argument containing spaces should be wrapped in quotes.
+        :param stdin: Input for command.
+        :param cwd: In which directory the command should be run.
+        :raises ValueError: Command is both running and dead.
+        :return: Tuple with return code, stdout and stderr.
+        """
+        proc = await create_subprocess_exec(
+            command,
+            *args,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=cwd,
+        )
+        if stdin is None:
+            (stdout, stderr) = await proc.communicate()
+        else:
+            (stdout, stderr) = await proc.communicate(stdin.encode("utf-8"))
+        if proc.returncode is None:
+            raise ValueError("Unkown return code")
+        return (proc.returncode, stdout.decode("utf-8"), stderr.decode("utf-8"))
+
+    def close(self) -> None:
+        """Close any connections runner has."""
+
+
+class SshCommandRunner(CommandRunner):
+    """Run command on a remote machine using SSH."""
+
+    def __init__(
+        self,
+        config: SshConnectConfig,
+    ):
+        """Constructor.
+
+        :param config: SSH connection configuration.
+        """
+        self.config = config
+        self.conn: Optional[SSHClientConnection] = None
+
+    async def run(
+        self,
+        command: str,
+        args: list[str],
+        stdin: Optional[str] = None,
+        cwd: Optional[Path] = None,
+    ) -> tuple[int, str, str]:
+        """Run command.
+
+        :param command: Command to execute. Command can not contain spaces.
+        :param args: List of arguments for command.
+            Argument containing spaces should be wrapped in quotes.
+        :param stdin: Input for command.
+        :param cwd: In which directory the command should be run.
+        :raises ValueError: Command is both running and dead.
+        :return: Tuple with return code, stdout and stderr.
+        """
+        remote_command = command
+        if args:
+            joined_args = " ".join(args)
+            remote_command = f"{remote_command} {joined_args}"
+        if cwd is not None:
+            remote_command = f"cd {cwd} && {remote_command}"
+
+        if self.conn is None:
+            self.conn = await ssh_connect(self.config)
+
+        result = await self.conn.run(remote_command, input=stdin)
+        if (  # noqa: WPS337
+            result.returncode is None
+            or not isinstance(result.stdout, str)
+            or not isinstance(result.stderr, str)
+        ):
+            raise ValueError(
+                "Unknown return code or incorrect format of stdout or stderr",
+            )
+        return (result.returncode, result.stdout, result.stderr)
+
+    def close(self) -> None:
+        """Close any connections runner has."""
+        if self.conn:
+            self.conn.close()
+
+    def __enter__(self) -> "SshCommandRunner":
+        return self
+
+    def __exit__(self, *args: list[Any]) -> None:
+        self.close()

--- a/bartender/schedulers/slurm.py
+++ b/bartender/schedulers/slurm.py
@@ -72,6 +72,7 @@ class SlurmScheduler(AbstractScheduler):
                 f"Error running sbatch, exited with {returncode}: {stderr}",
             )
 
+        #  Get the "4" out of string like "Submitted batch job 4"
         return stdout.strip().split(" ")[-1]
 
     async def state(self, job_id: str) -> State:

--- a/bartender/schedulers/slurm.py
+++ b/bartender/schedulers/slurm.py
@@ -1,0 +1,157 @@
+from abc import ABC, abstractmethod
+from asyncio import create_subprocess_exec
+from asyncio.subprocess import PIPE
+from textwrap import dedent
+from typing import IO, Any, Optional, Union
+
+from bartender.db.models.job_model import State
+from bartender.schedulers.abstract import AbstractScheduler, JobDescription
+
+
+class Terminal(ABC):
+    @abstractmethod
+    async def exec(
+        command: str,
+        *args: list[str],
+        stdout: Union[None, PIPE, str],
+        stderr: Union[None, PIPE, str] = None,
+        cwd: str = None,
+    ) -> tuple(str, str, str):
+        """Execute command."""
+
+
+class LocalTerminal(Terminal):
+    async def exec(
+        command: str,
+        *args: list[str],
+        stdin: Union[None, int, IO[Any]] = None,
+        stdout: Union[None, int, IO[Any]] = None,
+        stderr: Union[None, int, IO[Any]] = None,
+        cwd: str = None,
+    ) -> tuple(str, str, str):
+        proc = await create_subprocess_exec(
+            command, *args, stdout=stdout, stderr=stderr, cwd=cwd
+        )
+        if stdout is None and stderr is None:
+            returncode = await proc.wait()
+            return (returncode, "", "")
+        else:
+            (stdout, stderr) = await proc.communicate(stdin)
+            return (proc.returncode, stdout, stderr)
+
+
+class SSHTerminal(Terminal):
+    async def exec(
+        command: str,
+        *args: list[str],
+        stdin: Union[None, int, IO[Any]] = None,
+        stdout: Union[None, int, IO[Any]] = None,
+        stderr: Union[None, int, IO[Any]] = None,
+        cwd: str = None,
+    ) -> tuple(str, str, str):
+        # TODO find ssh client
+        raise NotImplementedError()
+
+
+class SlurmScheduler(AbstractScheduler):
+    def __init__(
+        self,
+        terminal: Terminal,
+        partition: Optional[str] = None,
+        time: Optional[str] = None,
+        extra_options: list[str] = [],
+    ):
+        # TODO which option should be set to per scheduler or per job description?
+        self.terminal = terminal
+        self.partition = partition
+        self.time = time
+        self.extra_options = extra_options
+
+    async def submit(self, description: JobDescription) -> str:  # noqa: D102):
+        script = self._submit_script(description)
+        command = "sbatch"
+        proc = await create_subprocess_exec(
+            command,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=description.job_dir,
+        )
+        (stdout, stderr) = await proc.communicate(script)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Error running sbatch, exited with {proc.returncode}: {stderr}",
+            )
+
+        job_id = stdout.strip().split(" ")[-1]
+        return job_id
+
+    async def state(self, job_id: str) -> State:
+        command = "squeue"
+        args = ["-j", job_id, "--noheader", "--format=%T"]
+        proc = await create_subprocess_exec(
+            command,
+            *args,
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+        (stdout, stderr) = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Error running squeue, exited with {proc.returncode}: {stderr}",
+            )
+        slurm_state = stdout.strip()
+        # See https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
+        status_map: dict[str, State] = {
+            "PENDING": "queued",
+            "CONFIGURING": "queud",
+            "RUNNING": "running",
+            "SUSPENDED": "running",
+            "COMPLETING": "running",
+            "STAGE_OUT": "running",
+            "CANCELLED": "error",
+            "COMPLETED": "ok",
+            "FAILED": "error",
+            "TIMEOUT": "error",
+            "PREEMPTED": "error",
+            "NODE_FAIL": "error",
+            "SPECIAL_EXIT": "error",
+        }
+        try:
+            return status_map[slurm_state]
+        except KeyError:
+            # fallback to error when slurm state code is unmapped.
+            return "error"
+
+    async def cancel(self, job_id: str) -> None:
+        command = "scancel"
+        args = [job_id]
+        proc = await create_subprocess_exec(
+            command,
+            *args,
+        )
+        await proc.wait()
+        # TODO check if succesfull
+
+    def _submit_script(self, description: JobDescription) -> str:
+        partition_line = ""
+        if self.partition:
+            partition_line = f"#SBATCH --partition={self.partition}"
+        time_line = ""
+        if self.time:
+            time_line = f"#SBATCH --time={self.time}"
+
+        # TODO filter out options already set
+        extra_option_lines = [f"#SBATCH {extra}\n" for extra in self.extra_options]
+        script = dedent(
+            f"""#!/bin/bash
+        {extra_option_lines}
+        {partition_line}
+        {time_line}
+        #SBATCH -output=stdout.txt
+        #SBATCH -error=stderr.txt
+        cd {description.job_dir}
+        {description.command}
+        echo -n $? > returncode
+        """,
+        )
+        return script

--- a/bartender/schedulers/slurm.py
+++ b/bartender/schedulers/slurm.py
@@ -45,7 +45,7 @@ class SlurmScheduler(AbstractScheduler):
         :param partition: Partition in which all jobs should be submitted.
         :param time: Limit on the total run time of the job.
         :param extra_options: Escape hatch to add extra options to job script.
-            The string `#SBATCH {extra_options[0]}` will be appended to job script.
+            The string `#SBATCH {extra_options[i]}` will be appended to job script.
         """
         # TODO which option should be set to per scheduler or per job description?
         self.runner = runner

--- a/bartender/schedulers/slurm.py
+++ b/bartender/schedulers/slurm.py
@@ -1,128 +1,69 @@
-from abc import ABC, abstractmethod
-from asyncio import create_subprocess_exec
-from asyncio.subprocess import PIPE
 from textwrap import dedent
 from typing import Optional
 
-from asyncssh import connect
-
 from bartender.db.models.job_model import State
 from bartender.schedulers.abstract import AbstractScheduler, JobDescription
+from bartender.schedulers.runner import CommandRunner
 
 
-class CommandRunner(ABC):
-    @abstractmethod
-    async def run(
-        command: str,
-        *args: list[str],
-        stdin: Optional[str] = None,
-        cwd: Optional[str] = None,
-    ) -> tuple[int, str, str]:
-        """Run command.
-
-        :param command: Command to execute. Command can not contain spaces.
-        :param args: List of arguments for command. Argument containing spaces should be wrapped in quotes.
-        :param stdin: Input for command.
-        :param cwd: In which directory the command should be run.
-        :return: Tuple with return code, stdout and stderr.
-        """
-
-
-class LocalCommandRunner(CommandRunner):
-    async def run(
-        self,
-        command: str,
-        *args: list[str],
-        stdin: Optional[str] = None,
-        cwd: Optional[str] = None,
-    ) -> tuple[int, str, str]:
-        proc = await create_subprocess_exec(
-            command, *args, stdout=PIPE, stderr=PIPE, cwd=cwd
-        )
-        (stdout, stderr) = await proc.communicate(stdin)
-        return (proc.returncode, stdout, stderr)
-
-
-class SSHCommandRunner(CommandRunner):
-    def __init__(
-        self,
-        hostname: str,
-        port: Optional[int] = None,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-    ):
-        self.hostname = hostname
-        self.port = port
-        self.username = username
-        self.password = password
-        self.conn = None
-
-    async def _connect(self):
-        conn_vargs = {
-            "known_hosts": None,
-        }
-        if self.password is not None:
-            conn_vargs["agent_path"] = None
-
-        self.conn = await connect(
-            host=self.hostname,
-            port=self.port,
-            username=self.username,
-            password=self.password,
-            **conn_vargs,
-        )
-
-    async def run(
-        self,
-        command: str,
-        *args: list[str],
-        stdin: Optional[str] = None,
-        cwd: Optional[str] = None,
-    ) -> tuple[int, str, str]:
-        remote_command = command
-        if args:
-            remote_command = f'{remote_command} {" ".join(args)}'
-        if cwd is not None:
-            remote_command = f"cd {cwd} && {remote_command}"
-
-        if self.conn is None:
-            await self._connect()
-
-        result = await self.conn.run(remote_command, input=stdin)
-
-        print((command, args, result.returncode, result.stdout, result.stderr))
-        return (result.returncode, result.stdout, result.stderr)
-
-    def __del__(self):
-        self.close()
-
-    def close(self):
-        if self.conn:
-            self.conn.close()
+def _map_slurm_state(slurm_state: str) -> State:
+    status_map: dict[str, State] = {
+        "PENDING": "queued",
+        "CONFIGURING": "queued",
+        "RUNNING": "running",
+        "SUSPENDED": "running",
+        "COMPLETING": "running",
+        "STAGE_OUT": "running",
+        "CANCELLED": "error",
+        "COMPLETED": "ok",
+        "FAILED": "error",
+        "TIMEOUT": "error",
+        "PREEMPTED": "error",
+        "NODE_FAIL": "error",
+        "SPECIAL_EXIT": "error",
+    }
+    try:
+        return status_map[slurm_state]
+    except KeyError:
+        # fallback to error when slurm state code is unmapped.
+        return "error"
 
 
 class SlurmScheduler(AbstractScheduler):
+    """Slurm batch scheduler."""
+
     def __init__(
         self,
         runner: CommandRunner,
         partition: Optional[str] = None,
         time: Optional[str] = None,
-        extra_options: list[str] = [],
+        extra_options: Optional[list[str]] = None,
     ):
+        """Constructor.
+
+        :param runner: Runner for running commands. Can be local or ssh.
+        :param partition: Partition in which all jobs should be submitted.
+        :param time: Limit on the total run time of the job.
+        :param extra_options: Escape hatch to add extra options to job script.
+            The string `#SBATCH {extra_options[0]}` will be appended to job script.
+        """
         # TODO which option should be set to per scheduler or per job description?
         self.runner = runner
         self.partition = partition
         self.time = time
-        self.extra_options = extra_options
+        if extra_options is None:
+            self.extra_options = []
+        else:
+            self.extra_options = extra_options
 
     async def submit(self, description: JobDescription) -> str:  # noqa: D102):
-        # TODO check that if runniner is a SSHCommandRunner then description.jobdir must be on a shared filesystem
+        # TODO if runner is a SSHCommandRunner then description.jobdir
+        # must be on a shared filesystem or remote filesystem
         script = self._submit_script(description)
-        print(script)
         command = "sbatch"
-        # command = 'hostname'
         (returncode, stdout, stderr) = await self.runner.run(
             command,
+            args=[],
             cwd=description.job_dir,
             stdin=script,
         )
@@ -131,56 +72,52 @@ class SlurmScheduler(AbstractScheduler):
                 f"Error running sbatch, exited with {returncode}: {stderr}",
             )
 
-        job_id = stdout.strip().split(" ")[-1]
-        return job_id
+        return stdout.strip().split(" ")[-1]
 
     async def state(self, job_id: str) -> State:
-        command = "squeue"
+        """Get state of a job.
+
+        Once job is completed, then scheduler can forget job.
+
+        :param job_id: Identifier of job.
+        :return: State of job.
+        """
         args = ["-j", job_id, "--noheader", "--format=%T"]
-        (returncode, stdout, stderr) = await self.runner.run(command, *args)
+        (returncode, stdout, stderr) = await self.runner.run("squeue", args)
         if returncode != 0 or stdout == "":
-            print("squeue failed")
-            # Completed jobs cannot be retrieved with squeue,
-            # depending on whether slurm has configured accounting and job is not too old
+            # Completed jobs cannot be retrieved with squeue, depending on
+            # whether slurm has configured accounting and job is not too old
             # the state can be requested using `sacct`
-            command = "sacct"
-            args = ["-j", job_id, "--noheader", "--format=state"]
-            (returncode, stdout, stderr) = await self.runner.run(command, *args)
-            if returncode != 0:
-                raise RuntimeError(
-                    f"Error running sacct, exited with {returncode}: {stderr}",
-                )
+            stdout = await self._state_from_accounting(job_id)
         slurm_state = stdout.strip()
         # See https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
-        status_map: dict[str, State] = {
-            "PENDING": "queued",
-            "CONFIGURING": "queud",
-            "RUNNING": "running",
-            "SUSPENDED": "running",
-            "COMPLETING": "running",
-            "STAGE_OUT": "running",
-            "CANCELLED": "error",
-            "COMPLETED": "ok",
-            "FAILED": "error",
-            "TIMEOUT": "error",
-            "PREEMPTED": "error",
-            "NODE_FAIL": "error",
-            "SPECIAL_EXIT": "error",
-        }
-        try:
-            return status_map[slurm_state]
-        except KeyError:
-            # fallback to error when slurm state code is unmapped.
-            return "error"
+        return _map_slurm_state(slurm_state)
 
     async def cancel(self, job_id: str) -> None:
+        """Cancel a queued or running job.
+
+        Once a queued job is cancelled, then the scheduler can forget job.
+
+        :param job_id: Identifier of job.
+        """
         command = "scancel"
         args = [job_id]
-        await self.runner.run(command, *args)
+        await self.runner.run(command, args)
         # TODO check if succesfull
 
-    async def close(self):
+    async def close(self) -> None:
+        """Cancel all runnning jobs and make scheduler unable to work."""
         self.runner.close()
+
+    async def _state_from_accounting(self, job_id: str) -> str:
+        command = "sacct"
+        args = ["-j", job_id, "--noheader", "--format=state"]
+        (returncode, stdout, stderr) = await self.runner.run(command, args)
+        if returncode != 0:
+            raise RuntimeError(
+                f"Error running sacct, exited with {returncode}: {stderr}",
+            )
+        return stdout
 
     def _submit_script(self, description: JobDescription) -> str:
         partition_line = ""

--- a/bartender/schedulers/slurm.py
+++ b/bartender/schedulers/slurm.py
@@ -2,84 +2,133 @@ from abc import ABC, abstractmethod
 from asyncio import create_subprocess_exec
 from asyncio.subprocess import PIPE
 from textwrap import dedent
-from typing import IO, Any, Optional, Union
+from typing import Optional
+
+from asyncssh import connect
 
 from bartender.db.models.job_model import State
 from bartender.schedulers.abstract import AbstractScheduler, JobDescription
 
 
-class Terminal(ABC):
+class CommandRunner(ABC):
     @abstractmethod
-    async def exec(
+    async def run(
         command: str,
         *args: list[str],
-        stdout: Union[None, PIPE, str],
-        stderr: Union[None, PIPE, str] = None,
-        cwd: str = None,
-    ) -> tuple(str, str, str):
-        """Execute command."""
+        stdin: Optional[str] = None,
+        cwd: Optional[str] = None,
+    ) -> tuple[int, str, str]:
+        """Run command.
+
+        :param command: Command to execute. Command can not contain spaces.
+        :param args: List of arguments for command. Argument containing spaces should be wrapped in quotes.
+        :param stdin: Input for command.
+        :param cwd: In which directory the command should be run.
+        :return: Tuple with return code, stdout and stderr.
+        """
 
 
-class LocalTerminal(Terminal):
-    async def exec(
+class LocalCommandRunner(CommandRunner):
+    async def run(
+        self,
         command: str,
         *args: list[str],
-        stdin: Union[None, int, IO[Any]] = None,
-        stdout: Union[None, int, IO[Any]] = None,
-        stderr: Union[None, int, IO[Any]] = None,
-        cwd: str = None,
-    ) -> tuple(str, str, str):
+        stdin: Optional[str] = None,
+        cwd: Optional[str] = None,
+    ) -> tuple[int, str, str]:
         proc = await create_subprocess_exec(
-            command, *args, stdout=stdout, stderr=stderr, cwd=cwd
+            command, *args, stdout=PIPE, stderr=PIPE, cwd=cwd
         )
-        if stdout is None and stderr is None:
-            returncode = await proc.wait()
-            return (returncode, "", "")
-        else:
-            (stdout, stderr) = await proc.communicate(stdin)
-            return (proc.returncode, stdout, stderr)
+        (stdout, stderr) = await proc.communicate(stdin)
+        return (proc.returncode, stdout, stderr)
 
 
-class SSHTerminal(Terminal):
-    async def exec(
+class SSHCommandRunner(CommandRunner):
+    def __init__(
+        self,
+        hostname: str,
+        port: Optional[int] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+    ):
+        self.hostname = hostname
+        self.port = port
+        self.username = username
+        self.password = password
+        self.conn = None
+
+    async def _connect(self):
+        conn_vargs = {
+            "known_hosts": None,
+        }
+        if self.password is not None:
+            conn_vargs["agent_path"] = None
+
+        self.conn = await connect(
+            host=self.hostname,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+            **conn_vargs,
+        )
+
+    async def run(
+        self,
         command: str,
         *args: list[str],
-        stdin: Union[None, int, IO[Any]] = None,
-        stdout: Union[None, int, IO[Any]] = None,
-        stderr: Union[None, int, IO[Any]] = None,
-        cwd: str = None,
-    ) -> tuple(str, str, str):
-        # TODO find ssh client
-        raise NotImplementedError()
+        stdin: Optional[str] = None,
+        cwd: Optional[str] = None,
+    ) -> tuple[int, str, str]:
+        remote_command = command
+        if args:
+            remote_command = f'{remote_command} {" ".join(args)}'
+        if cwd is not None:
+            remote_command = f"cd {cwd} && {remote_command}"
+
+        if self.conn is None:
+            await self._connect()
+
+        result = await self.conn.run(remote_command, input=stdin)
+
+        print((command, args, result.returncode, result.stdout, result.stderr))
+        return (result.returncode, result.stdout, result.stderr)
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        if self.conn:
+            self.conn.close()
 
 
 class SlurmScheduler(AbstractScheduler):
     def __init__(
         self,
-        terminal: Terminal,
+        runner: CommandRunner,
         partition: Optional[str] = None,
         time: Optional[str] = None,
         extra_options: list[str] = [],
     ):
         # TODO which option should be set to per scheduler or per job description?
-        self.terminal = terminal
+        self.runner = runner
         self.partition = partition
         self.time = time
         self.extra_options = extra_options
 
     async def submit(self, description: JobDescription) -> str:  # noqa: D102):
+        # TODO check that if runniner is a SSHCommandRunner then description.jobdir must be on a shared filesystem
         script = self._submit_script(description)
+        print(script)
         command = "sbatch"
-        proc = await create_subprocess_exec(
+        # command = 'hostname'
+        (returncode, stdout, stderr) = await self.runner.run(
             command,
-            stdout=PIPE,
-            stderr=PIPE,
             cwd=description.job_dir,
+            stdin=script,
         )
-        (stdout, stderr) = await proc.communicate(script)
-        if proc.returncode != 0:
+        if returncode != 0:
             raise RuntimeError(
-                f"Error running sbatch, exited with {proc.returncode}: {stderr}",
+                f"Error running sbatch, exited with {returncode}: {stderr}",
             )
 
         job_id = stdout.strip().split(" ")[-1]
@@ -88,17 +137,19 @@ class SlurmScheduler(AbstractScheduler):
     async def state(self, job_id: str) -> State:
         command = "squeue"
         args = ["-j", job_id, "--noheader", "--format=%T"]
-        proc = await create_subprocess_exec(
-            command,
-            *args,
-            stdout=PIPE,
-            stderr=PIPE,
-        )
-        (stdout, stderr) = await proc.communicate()
-        if proc.returncode != 0:
-            raise RuntimeError(
-                f"Error running squeue, exited with {proc.returncode}: {stderr}",
-            )
+        (returncode, stdout, stderr) = await self.runner.run(command, *args)
+        if returncode != 0 or stdout == "":
+            print("squeue failed")
+            # Completed jobs cannot be retrieved with squeue,
+            # depending on whether slurm has configured accounting and job is not too old
+            # the state can be requested using `sacct`
+            command = "sacct"
+            args = ["-j", job_id, "--noheader", "--format=state"]
+            (returncode, stdout, stderr) = await self.runner.run(command, *args)
+            if returncode != 0:
+                raise RuntimeError(
+                    f"Error running sacct, exited with {returncode}: {stderr}",
+                )
         slurm_state = stdout.strip()
         # See https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
         status_map: dict[str, State] = {
@@ -125,12 +176,11 @@ class SlurmScheduler(AbstractScheduler):
     async def cancel(self, job_id: str) -> None:
         command = "scancel"
         args = [job_id]
-        proc = await create_subprocess_exec(
-            command,
-            *args,
-        )
-        await proc.wait()
+        await self.runner.run(command, *args)
         # TODO check if succesfull
+
+    async def close(self):
+        self.runner.close()
 
     def _submit_script(self, description: JobDescription) -> str:
         partition_line = ""
@@ -141,17 +191,17 @@ class SlurmScheduler(AbstractScheduler):
             time_line = f"#SBATCH --time={self.time}"
 
         # TODO filter out options already set
-        extra_option_lines = [f"#SBATCH {extra}\n" for extra in self.extra_options]
-        script = dedent(
-            f"""#!/bin/bash
-        {extra_option_lines}
-        {partition_line}
-        {time_line}
-        #SBATCH -output=stdout.txt
-        #SBATCH -error=stderr.txt
-        cd {description.job_dir}
-        {description.command}
-        echo -n $? > returncode
-        """,
+        extra_option_lines = "\n".join(
+            [f"#SBATCH {extra}" for extra in self.extra_options],
         )
-        return script
+        script = f"""\
+            #!/bin/bash
+            {extra_option_lines}
+            {partition_line}
+            {time_line}
+            #SBATCH --output=stdout.txt
+            #SBATCH --error=stderr.txt
+            {description.command}
+            echo -n $? > returncode
+        """
+        return dedent(script)

--- a/bartender/tests/schedulers/test_slurm.py
+++ b/bartender/tests/schedulers/test_slurm.py
@@ -1,0 +1,47 @@
+from asyncio import sleep
+from pathlib import Path
+
+import pytest
+from testcontainers.core.container import DockerContainer
+
+from bartender.schedulers.abstract import JobDescription
+from bartender.schedulers.slurm import SlurmScheduler, SSHTerminal
+
+
+class SlurmContainer(DockerContainer):
+    def __init__(self, image="xenonmiddleware/slurm:20"):
+        super(SlurmContainer, self).__init__(image=image)
+        self.port_to_expose = 22
+        self.with_exposed_ports(self.port_to_expose)
+
+    def terminal(self):
+        username = "xenon"
+        password = "javagat"
+        hostname = self.get_container_host_ip()
+        port = self.get_exposed_port(self.port_to_expose)
+        # TODO configure terminal
+        return SSHTerminal()
+
+
+@pytest.fixture
+def slurm_server_terminal():
+    with SlurmContainer() as container:
+        yield container.terminal()
+
+
+@pytest.mark.anyio
+async def test_ok_running_job(tmp_path: Path, slurm_server_terminal) -> None:
+    try:
+        scheduler = SlurmScheduler(slurm_server_terminal)
+        description = JobDescription(command="echo -n hello", job_dir=str(tmp_path))
+
+        jid = await scheduler.submit(description)
+
+        # Wait for job to complete
+        # TODO poll state as slurm is slower
+        await sleep(0.01)
+        assert (await scheduler.state(jid)) == "ok"
+        assert (tmp_path / "returncode").read_text() == "0"
+        assert (tmp_path / "stdout.txt").read_text() == "hello"
+    finally:
+        await scheduler.close()

--- a/bartender/tests/schedulers/test_slurm.py
+++ b/bartender/tests/schedulers/test_slurm.py
@@ -1,11 +1,16 @@
+import asyncio
 from asyncio import sleep
 from pathlib import Path
 
+import asyncssh
 import pytest
+from asyncssh.misc import ConnectionLost
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
 
+from bartender.db.models.job_model import CompletedStates
 from bartender.schedulers.abstract import JobDescription
-from bartender.schedulers.slurm import SlurmScheduler, SSHTerminal
+from bartender.schedulers.slurm import SlurmScheduler, SSHCommandRunner
 
 
 class SlurmContainer(DockerContainer):
@@ -14,34 +19,70 @@ class SlurmContainer(DockerContainer):
         self.port_to_expose = 22
         self.with_exposed_ports(self.port_to_expose)
 
-    def terminal(self):
+    async def _ping(self):
+        vargs = {
+            "host": self.get_container_host_ip(),
+            "port": int(self.get_exposed_port(self.port_to_expose)),
+            "username": "xenon",
+            "password": "javagat",
+            "known_hosts": None,
+            "agent_path": None,
+        }
+        async with asyncssh.connect(**vargs) as conn:
+            await conn.run('echo "ping"', check=True)
+
+    @wait_container_is_ready(ConnectionLost)
+    def _connect(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self._ping())
+
+    def get_client(self):
         username = "xenon"
         password = "javagat"
         hostname = self.get_container_host_ip()
-        port = self.get_exposed_port(self.port_to_expose)
-        # TODO configure terminal
-        return SSHTerminal()
+        port = int(self.get_exposed_port(self.port_to_expose))
+        print((hostname, port))
+        return SSHCommandRunner(hostname, port, username, password)
+
+    def start(self):
+        super().start()
+        self._connect()
+        return self
 
 
 @pytest.fixture
-def slurm_server_terminal():
+def slurm_server():
     with SlurmContainer() as container:
-        yield container.terminal()
+        yield container
 
 
 @pytest.mark.anyio
-async def test_ok_running_job(tmp_path: Path, slurm_server_terminal) -> None:
+async def test_ok_running_job(tmp_path: Path, slurm_server) -> None:
     try:
-        scheduler = SlurmScheduler(slurm_server_terminal)
-        description = JobDescription(command="echo -n hello", job_dir=str(tmp_path))
+        client = slurm_server.get_client()
+        scheduler = SlurmScheduler(runner=client)
+        print("submit")
+        description = JobDescription(
+            command="echo -n hello"
+            # , job_dir=str(tmp_path)
+            # tmp_path is not owned by xenon user, so cd fails, use writeable path
+            ,
+            job_dir="/tmp",
+        )
 
         jid = await scheduler.submit(description)
 
-        # Wait for job to complete
-        # TODO poll state as slurm is slower
-        await sleep(0.01)
-        assert (await scheduler.state(jid)) == "ok"
-        assert (tmp_path / "returncode").read_text() == "0"
-        assert (tmp_path / "stdout.txt").read_text() == "hello"
+        print("submitted")
+        print(jid)
+        for _ in range(30):
+            state = await scheduler.state(jid)
+            if state in CompletedStates:
+                break
+            await sleep(0.5)
+
+        assert state == "ok"
+        # TODO deal with files in container
+        # assert (tmp_path / "returncode").read_text() == "0"
+        # assert (tmp_path / "stdout.txt").read_text() == "hello"
     finally:
         await scheduler.close()

--- a/bartender/tests/schedulers/test_slurm.py
+++ b/bartender/tests/schedulers/test_slurm.py
@@ -1,88 +1,140 @@
-import asyncio
-from asyncio import sleep
+from asyncio import new_event_loop, sleep
 from pathlib import Path
+from typing import Generator
 
-import asyncssh
 import pytest
 from asyncssh.misc import ConnectionLost
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
+from bartender._ssh_utils import SshConnectConfig
 from bartender.db.models.job_model import CompletedStates
+from bartender.filesystems.sftp import SftpFileSystem
 from bartender.schedulers.abstract import JobDescription
-from bartender.schedulers.slurm import SlurmScheduler, SSHCommandRunner
+from bartender.schedulers.runner import SshCommandRunner
+from bartender.schedulers.slurm import SlurmScheduler
 
 
 class SlurmContainer(DockerContainer):
-    def __init__(self, image="xenonmiddleware/slurm:20"):
-        super(SlurmContainer, self).__init__(image=image)
+    def __init__(self, image: str = "xenonmiddleware/slurm:20"):
+        super().__init__(image=image)
         self.port_to_expose = 22
         self.with_exposed_ports(self.port_to_expose)
 
-    async def _ping(self):
-        vargs = {
-            "host": self.get_container_host_ip(),
-            "port": int(self.get_exposed_port(self.port_to_expose)),
-            "username": "xenon",
-            "password": "javagat",
-            "known_hosts": None,
-            "agent_path": None,
-        }
-        async with asyncssh.connect(**vargs) as conn:
-            await conn.run('echo "ping"', check=True)
-
-    @wait_container_is_ready(ConnectionLost)
-    def _connect(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self._ping())
-
-    def get_client(self):
+    def get_config(self) -> SshConnectConfig:
         username = "xenon"
-        password = "javagat"
+        password = "javagat"  # noqa: S105
         hostname = self.get_container_host_ip()
         port = int(self.get_exposed_port(self.port_to_expose))
-        print((hostname, port))
-        return SSHCommandRunner(hostname, port, username, password)
+        return {
+            "hostname": hostname,
+            "port": port,
+            "username": username,
+            "password": password,
+        }
 
-    def start(self):
+    def get_runner(self) -> SshCommandRunner:
+        return SshCommandRunner(self.get_config())
+
+    def get_filesystem(self) -> SftpFileSystem:
+        home_dir = Path("/home/xenon")
+        return SftpFileSystem(entry=home_dir, config=self.get_config())
+
+    def start(self) -> "SlurmContainer":
         super().start()
         self._connect()
         return self
 
+    async def _ping(self) -> None:
+        with self.get_runner() as conn:
+            await conn.run("echo", [])
+
+    @wait_container_is_ready(ConnectionLost)
+    def _connect(self) -> None:
+        loop = new_event_loop()
+        try:
+            loop.run_until_complete(self._ping())
+        finally:
+            loop.close()
+
 
 @pytest.fixture
-def slurm_server():
+def slurm_server() -> Generator[SlurmContainer, None, None]:
     with SlurmContainer() as container:
         yield container
 
 
 @pytest.mark.anyio
-async def test_ok_running_job(tmp_path: Path, slurm_server) -> None:
+async def test_ok_running_job_with_input_and_output_file(
+    tmp_path: Path,
+    slurm_server: SlurmContainer,
+) -> None:
+    job_dir = tmp_path
     try:
-        client = slurm_server.get_client()
+        client = slurm_server.get_runner()
         scheduler = SlurmScheduler(runner=client)
-        print("submit")
+        (job_dir / "input").write_text("Lorem ipsum")
         description = JobDescription(
-            command="echo -n hello"
-            # , job_dir=str(tmp_path)
-            # tmp_path is not owned by xenon user, so cd fails, use writeable path
-            ,
-            job_dir="/tmp",
+            command="echo -n hello && wc input > output",
+            job_dir=str(job_dir),
         )
+        fs = slurm_server.get_filesystem()
+        localized_description = fs.localize_description(description, job_dir.parent)
 
-        jid = await scheduler.submit(description)
+        await fs.upload(description, localized_description)
 
-        print("submitted")
-        print(jid)
-        for _ in range(30):
-            state = await scheduler.state(jid)
-            if state in CompletedStates:
-                break
-            await sleep(0.5)
+        jid = await scheduler.submit(localized_description)
 
-        assert state == "ok"
-        # TODO deal with files in container
-        # assert (tmp_path / "returncode").read_text() == "0"
-        # assert (tmp_path / "stdout.txt").read_text() == "hello"
+        await wait_for_job(scheduler, jid)
+
+        await fs.download(localized_description, description)
+
+        assert_output(job_dir)
+    finally:
+        await scheduler.close()
+
+
+def assert_output(job_dir: Path) -> None:
+    assert (job_dir / "returncode").read_text() == "0"
+    assert (job_dir / "stdout.txt").read_text() == "hello"
+    assert (job_dir / "stderr.txt").read_text() == ""
+    assert (job_dir / "input").exists()
+    assert (job_dir / "output").read_text().strip() == "0  2 11 input"
+
+
+async def wait_for_job(scheduler: SlurmScheduler, job_id: str) -> None:
+    for _ in range(30):
+        state = await scheduler.state(job_id)
+        if state in CompletedStates:
+            break
+        await sleep(0.5)
+
+    assert state == "ok"
+
+
+@pytest.mark.anyio
+async def test_ok_running_job_without_iofiles(
+    tmp_path: Path,
+    slurm_server: SlurmContainer,
+) -> None:
+    job_dir = tmp_path
+    try:
+        client = slurm_server.get_runner()
+        scheduler = SlurmScheduler(runner=client)
+        description = JobDescription(command="echo -n hello", job_dir=str(job_dir))
+        fs = slurm_server.get_filesystem()
+        localized_description = fs.localize_description(description, job_dir.parent)
+
+        await fs.upload(description, localized_description)
+
+        jid = await scheduler.submit(localized_description)
+
+        await wait_for_job(scheduler, jid)
+
+        await fs.download(localized_description, description)
+
+        assert (job_dir / "returncode").read_text() == "0"
+        assert (job_dir / "stdout.txt").read_text() == "hello"
+        assert (job_dir / "stderr.txt").read_text() == ""
     finally:
         await scheduler.close()

--- a/poetry.lock
+++ b/poetry.lock
@@ -248,6 +248,17 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+packaging = "*"
+
+[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -270,6 +281,24 @@ doh = ["h2 (>=4.1.0)", "httpx (>=0.21.1)", "requests (>=2.23.0,<3.0.0)", "reques
 idna = ["idna (>=2.1,<4.0)"]
 trio = ["trio (>=0.14,<0.20)"]
 wmi = ["wmi (>=1.5.1,<2.0.0)"]
+
+[[package]]
+name = "docker"
+version = "6.0.1"
+description = "A Python library for the Docker Engine API."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+packaging = ">=14.0"
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+websocket-client = ">=0.32.0"
+
+[package.extras]
+ssh = ["paramiko (>=2.4.3)"]
 
 [[package]]
 name = "docutils"
@@ -1037,12 +1066,38 @@ python-versions = "*"
 six = ">=1.4.0"
 
 [[package]]
+name = "pywin32"
+version = "305"
+description = "Python for Window Extensions"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "PyYAML"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.28.1"
+description = "Python HTTP for Humans."
+category = "dev"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "restructuredtext-lint"
@@ -1186,6 +1241,37 @@ python-versions = ">=3.8"
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
+name = "testcontainers"
+version = "3.7.0"
+description = "Library provides lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+deprecation = "*"
+docker = ">=4.0.0"
+wrapt = "*"
+
+[package.extras]
+arangodb = ["python-arango"]
+azurite = ["azure-storage-blob"]
+clickhouse = ["clickhouse-driver"]
+docker-compose = ["docker-compose"]
+google-cloud-pubsub = ["google-cloud-pubsub (<2)"]
+kafka = ["kafka-python"]
+keycloak = ["python-keycloak"]
+mongo = ["pymongo"]
+mssqlserver = ["pymssql"]
+mysql = ["pymysql", "sqlalchemy"]
+neo4j = ["neo4j"]
+oracle = ["cx-Oracle", "sqlalchemy"]
+postgresql = ["psycopg2-binary", "sqlalchemy"]
+rabbitmq = ["pika"]
+redis = ["redis"]
+selenium = ["selenium"]
+
+[[package]]
 name = "tokenize-rt"
 version = "4.2.1"
 description = "A wrapper around the stdlib `tokenize` which roundtrips."
@@ -1232,6 +1318,19 @@ description = "Ultra fast JSON encoder and decoder for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "urllib3"
+version = "1.26.12"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -1298,6 +1397,19 @@ python-versions = ">=3.7"
 anyio = ">=3.0.0,<4"
 
 [[package]]
+name = "websocket-client"
+version = "1.4.2"
+description = "WebSocket client for Python with low level API options"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
+
+[[package]]
 name = "websockets"
 version = "10.3"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
@@ -1335,6 +1447,14 @@ pygments = ">=2.4,<3.0"
 typing_extensions = ">=3.6,<5.0"
 
 [[package]]
+name = "wrapt"
+version = "1.14.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
 name = "yarl"
 version = "1.8.1"
 description = "Yet another URL library"
@@ -1361,7 +1481,7 @@ tokenize-rt = ">=2.1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "74b12f3305def62edf32755d544408fec8a905acb88a74dc3367775a1f871373"
+content-hash = "4d86992c8b6241276037d655f2266b1f139f4c8d2470a5bf5a3b46a05e5de63b"
 
 [metadata.files]
 aiofiles = [
@@ -1633,6 +1753,10 @@ darglint = [
     {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
 ]
+deprecation = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
+]
 distlib = [
     {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
     {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
@@ -1640,6 +1764,10 @@ distlib = [
 dnspython = [
     {file = "dnspython-2.2.1-py3-none-any.whl", hash = "sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f"},
     {file = "dnspython-2.2.1.tar.gz", hash = "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e"},
+]
+docker = [
+    {file = "docker-6.0.1-py3-none-any.whl", hash = "sha256:dbcb3bd2fa80dca0788ed908218bf43972772009b881ed1e20dfc29a65e49782"},
+    {file = "docker-6.0.1.tar.gz", hash = "sha256:896c4282e5c7af5c45e8b683b0b0c33932974fe6e50fc6906a0a83616ab3da97"},
 ]
 docutils = [
     {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
@@ -2114,6 +2242,22 @@ python-dotenv = [
 python-multipart = [
     {file = "python-multipart-0.0.5.tar.gz", hash = "sha256:f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43"},
 ]
+pywin32 = [
+    {file = "pywin32-305-cp310-cp310-win32.whl", hash = "sha256:421f6cd86e84bbb696d54563c48014b12a23ef95a14e0bdba526be756d89f116"},
+    {file = "pywin32-305-cp310-cp310-win_amd64.whl", hash = "sha256:73e819c6bed89f44ff1d690498c0a811948f73777e5f97c494c152b850fad478"},
+    {file = "pywin32-305-cp310-cp310-win_arm64.whl", hash = "sha256:742eb905ce2187133a29365b428e6c3b9001d79accdc30aa8969afba1d8470f4"},
+    {file = "pywin32-305-cp311-cp311-win32.whl", hash = "sha256:19ca459cd2e66c0e2cc9a09d589f71d827f26d47fe4a9d09175f6aa0256b51c2"},
+    {file = "pywin32-305-cp311-cp311-win_amd64.whl", hash = "sha256:326f42ab4cfff56e77e3e595aeaf6c216712bbdd91e464d167c6434b28d65990"},
+    {file = "pywin32-305-cp311-cp311-win_arm64.whl", hash = "sha256:4ecd404b2c6eceaca52f8b2e3e91b2187850a1ad3f8b746d0796a98b4cea04db"},
+    {file = "pywin32-305-cp36-cp36m-win32.whl", hash = "sha256:48d8b1659284f3c17b68587af047d110d8c44837736b8932c034091683e05863"},
+    {file = "pywin32-305-cp36-cp36m-win_amd64.whl", hash = "sha256:13362cc5aa93c2beaf489c9c9017c793722aeb56d3e5166dadd5ef82da021fe1"},
+    {file = "pywin32-305-cp37-cp37m-win32.whl", hash = "sha256:a55db448124d1c1484df22fa8bbcbc45c64da5e6eae74ab095b9ea62e6d00496"},
+    {file = "pywin32-305-cp37-cp37m-win_amd64.whl", hash = "sha256:109f98980bfb27e78f4df8a51a8198e10b0f347257d1e265bb1a32993d0c973d"},
+    {file = "pywin32-305-cp38-cp38-win32.whl", hash = "sha256:9dd98384da775afa009bc04863426cb30596fd78c6f8e4e2e5bbf4edf8029504"},
+    {file = "pywin32-305-cp38-cp38-win_amd64.whl", hash = "sha256:56d7a9c6e1a6835f521788f53b5af7912090674bb84ef5611663ee1595860fc7"},
+    {file = "pywin32-305-cp39-cp39-win32.whl", hash = "sha256:9d968c677ac4d5cbdaa62fd3014ab241718e619d8e36ef8e11fb930515a1e918"},
+    {file = "pywin32-305-cp39-cp39-win_amd64.whl", hash = "sha256:50768c6b7c3f0b38b7fb14dd4104da93ebced5f1a50dc0e834594bff6fbe1271"},
+]
 PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
@@ -2148,6 +2292,10 @@ PyYAML = [
     {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+requests = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 restructuredtext-lint = [
     {file = "restructuredtext_lint-1.4.0.tar.gz", hash = "sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"},
@@ -2231,6 +2379,9 @@ stevedore = [
     {file = "stevedore-4.0.0-py3-none-any.whl", hash = "sha256:87e4d27fe96d0d7e4fc24f0cbe3463baae4ec51e81d95fbe60d2474636e0c7d8"},
     {file = "stevedore-4.0.0.tar.gz", hash = "sha256:f82cc99a1ff552310d19c379827c2c64dd9f85a38bcd5559db2470161867b786"},
 ]
+testcontainers = [
+    {file = "testcontainers-3.7.0-py2.py3-none-any.whl", hash = "sha256:e40fece4085ae06f8facb067e83020e273738e31f958b01d2b5eaa84e2dab478"},
+]
 tokenize-rt = [
     {file = "tokenize_rt-4.2.1-py2.py3-none-any.whl", hash = "sha256:08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8"},
     {file = "tokenize_rt-4.2.1.tar.gz", hash = "sha256:0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94"},
@@ -2303,6 +2454,10 @@ ujson = [
     {file = "ujson-5.4.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:025758cf6561af6986d77cd4af9367ab56dde5c7c50f13f59e6964b4b25df73e"},
     {file = "ujson-5.4.0.tar.gz", hash = "sha256:6b953e09441e307504130755e5bd6b15850178d591f66292bba4608c4f7f9b00"},
 ]
+urllib3 = [
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+]
 uvicorn = [
     {file = "uvicorn-0.17.5-py3-none-any.whl", hash = "sha256:8adddf629b79857b48b999ae1b14d6c92c95d4d7840bd86461f09bee75f1653e"},
     {file = "uvicorn-0.17.5.tar.gz", hash = "sha256:c04a9c069111489c324f427501b3840d306c6b91a77b00affc136a840a3f45f1"},
@@ -2332,6 +2487,10 @@ virtualenv = [
 watchgod = [
     {file = "watchgod-0.8.2-py3-none-any.whl", hash = "sha256:2f3e8137d98f493ff58af54ea00f4d1433a6afe2ed08ab331a657df468c6bfce"},
     {file = "watchgod-0.8.2.tar.gz", hash = "sha256:cb11ff66657befba94d828e3b622d5fb76f22fbda1376f355f3e6e51e97d9450"},
+]
+websocket-client = [
+    {file = "websocket-client-1.4.2.tar.gz", hash = "sha256:d6e8f90ca8e2dd4e8027c4561adeb9456b54044312dba655e7cae652ceb9ae59"},
+    {file = "websocket_client-1.4.2-py3-none-any.whl", hash = "sha256:d6b06432f184438d99ac1f456eaf22fe1ade524c3dd16e661142dc54e9cba574"},
 ]
 websockets = [
     {file = "websockets-10.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:661f641b44ed315556a2fa630239adfd77bd1b11cb0b9d96ed8ad90b0b1e4978"},
@@ -2386,6 +2545,72 @@ websockets = [
 wemake-python-styleguide = [
     {file = "wemake-python-styleguide-0.16.1.tar.gz", hash = "sha256:4fcd78dd55732679b5fc8bc37fd7e04bbaa5cdc1b1a829ad265e8f6b0d853cf6"},
     {file = "wemake_python_styleguide-0.16.1-py3-none-any.whl", hash = "sha256:202c22ecfee1f5caf0555048602cd52f2435cd57903e6b0cd46b5aaa3f652140"},
+]
+wrapt = [
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
 ]
 yarl = [
     {file = "yarl-1.8.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:abc06b97407868ef38f3d172762f4069323de52f2b70d133d096a48d72215d28"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,6 +71,27 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxc
 test = ["flake8 (>=3.9.2,<3.10.0)", "pycodestyle (>=2.7.0,<2.8.0)", "uvloop (>=0.15.3)"]
 
 [[package]]
+name = "asyncssh"
+version = "2.12.0"
+description = "AsyncSSH: Asynchronous SSHv2 client and server library"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+cryptography = ">=3.1"
+typing-extensions = ">=3.6"
+
+[package.extras]
+bcrypt = ["bcrypt (>=3.1.3)"]
+fido2 = ["fido2 (>=0.9.2)"]
+gssapi = ["gssapi (>=1.2.0)"]
+libnacl = ["libnacl (>=1.4.2)"]
+pkcs11 = ["python-pkcs11 (>=0.7.0)"]
+pyopenssl = ["pyOpenSSL (>=17.0.0)"]
+pywin32 = ["pywin32 (>=227)"]
+
+[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -593,14 +614,15 @@ gitdb = ">=4.0.1,<5"
 
 [[package]]
 name = "greenlet"
-version = "1.1.3"
+version = "2.0.1"
 description = "Lightweight in-process concurrent programming"
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
-docs = ["Sphinx"]
+docs = ["Sphinx", "docutils (<0.18)"]
+test = ["faulthandler", "objgraph", "psutil"]
 
 [[package]]
 name = "h11"
@@ -1481,7 +1503,7 @@ tokenize-rt = ">=2.1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "4d86992c8b6241276037d655f2266b1f139f4c8d2470a5bf5a3b46a05e5de63b"
+content-hash = "89bc024a4fbae42ddcae621ba4b783a8a85620b3c01f8fcafe781248914f3a6a"
 
 [metadata.files]
 aiofiles = [
@@ -1531,6 +1553,10 @@ asyncpg = [
     {file = "asyncpg-0.25.0-cp39-cp39-win32.whl", hash = "sha256:f55918ded7b85723a5eaeb34e86e7b9280d4474be67df853ab5a7fa0cc7c6bf2"},
     {file = "asyncpg-0.25.0-cp39-cp39-win_amd64.whl", hash = "sha256:649e2966d98cc48d0646d9a4e29abecd8b59d38d55c256d5c857f6b27b7407ac"},
     {file = "asyncpg-0.25.0.tar.gz", hash = "sha256:63f8e6a69733b285497c2855464a34de657f2cccd25aeaeeb5071872e9382540"},
+]
+asyncssh = [
+    {file = "asyncssh-2.12.0-py3-none-any.whl", hash = "sha256:6841c4242c606fd51188c974ec2f4887efeec67ecdfa5b84140711dacd985ab3"},
+    {file = "asyncssh-2.12.0.tar.gz", hash = "sha256:274101322c4b941823aeed8e1ab6e7be5191686c6db2d2bd35afeba30505e780"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
@@ -1861,60 +1887,66 @@ GitPython = [
     {file = "GitPython-3.1.27.tar.gz", hash = "sha256:1c885ce809e8ba2d88a29befeb385fcea06338d3640712b59ca623c220bb5704"},
 ]
 greenlet = [
-    {file = "greenlet-1.1.3-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:8c287ae7ac921dfde88b1c125bd9590b7ec3c900c2d3db5197f1286e144e712b"},
-    {file = "greenlet-1.1.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:870a48007872d12e95a996fca3c03a64290d3ea2e61076aa35d3b253cf34cd32"},
-    {file = "greenlet-1.1.3-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:7c5227963409551ae4a6938beb70d56bf1918c554a287d3da6853526212fbe0a"},
-    {file = "greenlet-1.1.3-cp27-cp27m-win32.whl", hash = "sha256:9fae214f6c43cd47f7bef98c56919b9222481e833be2915f6857a1e9e8a15318"},
-    {file = "greenlet-1.1.3-cp27-cp27m-win_amd64.whl", hash = "sha256:de431765bd5fe62119e0bc6bc6e7b17ac53017ae1782acf88fcf6b7eae475a49"},
-    {file = "greenlet-1.1.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:510c3b15587afce9800198b4b142202b323bf4b4b5f9d6c79cb9a35e5e3c30d2"},
-    {file = "greenlet-1.1.3-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:9951dcbd37850da32b2cb6e391f621c1ee456191c6ae5528af4a34afe357c30e"},
-    {file = "greenlet-1.1.3-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:07c58e169bbe1e87b8bbf15a5c1b779a7616df9fd3e61cadc9d691740015b4f8"},
-    {file = "greenlet-1.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df02fdec0c533301497acb0bc0f27f479a3a63dcdc3a099ae33a902857f07477"},
-    {file = "greenlet-1.1.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c88e134d51d5e82315a7c32b914a58751b7353eb5268dbd02eabf020b4c4700"},
-    {file = "greenlet-1.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b41d19c0cfe5c259fe6c539fd75051cd39a5d33d05482f885faf43f7f5e7d26"},
-    {file = "greenlet-1.1.3-cp310-cp310-win_amd64.whl", hash = "sha256:6f5d4b2280ceea76c55c893827961ed0a6eadd5a584a7c4e6e6dd7bc10dfdd96"},
-    {file = "greenlet-1.1.3-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:184416e481295832350a4bf731ba619a92f5689bf5d0fa4341e98b98b1265bd7"},
-    {file = "greenlet-1.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd0404d154084a371e6d2bafc787201612a1359c2dee688ae334f9118aa0bf47"},
-    {file = "greenlet-1.1.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7a43bbfa9b6cfdfaeefbd91038dde65ea2c421dc387ed171613df340650874f2"},
-    {file = "greenlet-1.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce5b64dfe8d0cca407d88b0ee619d80d4215a2612c1af8c98a92180e7109f4b5"},
-    {file = "greenlet-1.1.3-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:903fa5716b8fbb21019268b44f73f3748c41d1a30d71b4a49c84b642c2fed5fa"},
-    {file = "greenlet-1.1.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:0118817c9341ef2b0f75f5af79ac377e4da6ff637e5ee4ac91802c0e379dadb4"},
-    {file = "greenlet-1.1.3-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:466ce0928e33421ee84ae04c4ac6f253a3a3e6b8d600a79bd43fd4403e0a7a76"},
-    {file = "greenlet-1.1.3-cp35-cp35m-win32.whl", hash = "sha256:65ad1a7a463a2a6f863661329a944a5802c7129f7ad33583dcc11069c17e622c"},
-    {file = "greenlet-1.1.3-cp35-cp35m-win_amd64.whl", hash = "sha256:7532a46505470be30cbf1dbadb20379fb481244f1ca54207d7df3bf0bbab6a20"},
-    {file = "greenlet-1.1.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:caff52cb5cd7626872d9696aee5b794abe172804beb7db52eed1fd5824b63910"},
-    {file = "greenlet-1.1.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:db41f3845eb579b544c962864cce2c2a0257fe30f0f1e18e51b1e8cbb4e0ac6d"},
-    {file = "greenlet-1.1.3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e8533f5111704d75de3139bf0b8136d3a6c1642c55c067866fa0a51c2155ee33"},
-    {file = "greenlet-1.1.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9537e4baf0db67f382eb29255a03154fcd4984638303ff9baaa738b10371fa57"},
-    {file = "greenlet-1.1.3-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8bfd36f368efe0ab2a6aa3db7f14598aac454b06849fb633b762ddbede1db90"},
-    {file = "greenlet-1.1.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0877a9a2129a2c56a2eae2da016743db7d9d6a05d5e1c198f1b7808c602a30e"},
-    {file = "greenlet-1.1.3-cp36-cp36m-win32.whl", hash = "sha256:88b04e12c9b041a1e0bcb886fec709c488192638a9a7a3677513ac6ba81d8e79"},
-    {file = "greenlet-1.1.3-cp36-cp36m-win_amd64.whl", hash = "sha256:4f166b4aca8d7d489e82d74627a7069ab34211ef5ebb57c300ec4b9337b60fc0"},
-    {file = "greenlet-1.1.3-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:cd16a89efe3a003029c87ff19e9fba635864e064da646bc749fc1908a4af18f3"},
-    {file = "greenlet-1.1.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5b756e6730ea59b2745072e28ad27f4c837084688e6a6b3633c8b1e509e6ae0e"},
-    {file = "greenlet-1.1.3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:9b2f7d0408ddeb8ea1fd43d3db79a8cefaccadd2a812f021333b338ed6b10aba"},
-    {file = "greenlet-1.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44b4817c34c9272c65550b788913620f1fdc80362b209bc9d7dd2f40d8793080"},
-    {file = "greenlet-1.1.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d58a5a71c4c37354f9e0c24c9c8321f0185f6945ef027460b809f4bb474bfe41"},
-    {file = "greenlet-1.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dd51d2650e70c6c4af37f454737bf4a11e568945b27f74b471e8e2a9fd21268"},
-    {file = "greenlet-1.1.3-cp37-cp37m-win32.whl", hash = "sha256:048d2bed76c2aa6de7af500ae0ea51dd2267aec0e0f2a436981159053d0bc7cc"},
-    {file = "greenlet-1.1.3-cp37-cp37m-win_amd64.whl", hash = "sha256:77e41db75f9958f2083e03e9dd39da12247b3430c92267df3af77c83d8ff9eed"},
-    {file = "greenlet-1.1.3-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:1626185d938d7381631e48e6f7713e8d4b964be246073e1a1d15c2f061ac9f08"},
-    {file = "greenlet-1.1.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1ec2779774d8e42ed0440cf8bc55540175187e8e934f2be25199bf4ed948cd9e"},
-    {file = "greenlet-1.1.3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f2f908239b7098799b8845e5936c2ccb91d8c2323be02e82f8dcb4a80dcf4a25"},
-    {file = "greenlet-1.1.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b181e9aa6cb2f5ec0cacc8cee6e5a3093416c841ba32c185c30c160487f0380"},
-    {file = "greenlet-1.1.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2cf45e339cabea16c07586306a31cfcc5a3b5e1626d365714d283732afed6809"},
-    {file = "greenlet-1.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6200a11f003ec26815f7e3d2ded01b43a3810be3528dd760d2f1fa777490c3cd"},
-    {file = "greenlet-1.1.3-cp38-cp38-win32.whl", hash = "sha256:db5b25265010a1b3dca6a174a443a0ed4c4ab12d5e2883a11c97d6e6d59b12f9"},
-    {file = "greenlet-1.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:095a980288fe05adf3d002fbb180c99bdcf0f930e220aa66fcd56e7914a38202"},
-    {file = "greenlet-1.1.3-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:cbc1eb55342cbac8f7ec159088d54e2cfdd5ddf61c87b8bbe682d113789331b2"},
-    {file = "greenlet-1.1.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:694ffa7144fa5cc526c8f4512665003a39fa09ef00d19bbca5c8d3406db72fbe"},
-    {file = "greenlet-1.1.3-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:aa741c1a8a8cc25eb3a3a01a62bdb5095a773d8c6a86470bde7f607a447e7905"},
-    {file = "greenlet-1.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3a669f11289a8995d24fbfc0e63f8289dd03c9aaa0cc8f1eab31d18ca61a382"},
-    {file = "greenlet-1.1.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76a53bfa10b367ee734b95988bd82a9a5f0038a25030f9f23bbbc005010ca600"},
-    {file = "greenlet-1.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fb0aa7f6996879551fd67461d5d3ab0c3c0245da98be90c89fcb7a18d437403"},
-    {file = "greenlet-1.1.3-cp39-cp39-win32.whl", hash = "sha256:5fbe1ab72b998ca77ceabbae63a9b2e2dc2d963f4299b9b278252ddba142d3f1"},
-    {file = "greenlet-1.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:ffe73f9e7aea404722058405ff24041e59d31ca23d1da0895af48050a07b6932"},
-    {file = "greenlet-1.1.3.tar.gz", hash = "sha256:bcb6c6dd1d6be6d38d6db283747d07fda089ff8c559a835236560a4410340455"},
+    {file = "greenlet-2.0.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:9ed358312e63bf683b9ef22c8e442ef6c5c02973f0c2a939ec1d7b50c974015c"},
+    {file = "greenlet-2.0.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4f09b0010e55bec3239278f642a8a506b91034f03a4fb28289a7d448a67f1515"},
+    {file = "greenlet-2.0.1-cp27-cp27m-win32.whl", hash = "sha256:1407fe45246632d0ffb7a3f4a520ba4e6051fc2cbd61ba1f806900c27f47706a"},
+    {file = "greenlet-2.0.1-cp27-cp27m-win_amd64.whl", hash = "sha256:3001d00eba6bbf084ae60ec7f4bb8ed375748f53aeaefaf2a37d9f0370558524"},
+    {file = "greenlet-2.0.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d566b82e92ff2e09dd6342df7e0eb4ff6275a3f08db284888dcd98134dbd4243"},
+    {file = "greenlet-2.0.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:0722c9be0797f544a3ed212569ca3fe3d9d1a1b13942d10dd6f0e8601e484d26"},
+    {file = "greenlet-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d37990425b4687ade27810e3b1a1c37825d242ebc275066cfee8cb6b8829ccd"},
+    {file = "greenlet-2.0.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be35822f35f99dcc48152c9839d0171a06186f2d71ef76dc57fa556cc9bf6b45"},
+    {file = "greenlet-2.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c140e7eb5ce47249668056edf3b7e9900c6a2e22fb0eaf0513f18a1b2c14e1da"},
+    {file = "greenlet-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d21681f09e297a5adaa73060737e3aa1279a13ecdcfcc6ef66c292cb25125b2d"},
+    {file = "greenlet-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fb412b7db83fe56847df9c47b6fe3f13911b06339c2aa02dcc09dce8bbf582cd"},
+    {file = "greenlet-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:c6a08799e9e88052221adca55741bf106ec7ea0710bca635c208b751f0d5b617"},
+    {file = "greenlet-2.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9e112e03d37987d7b90c1e98ba5e1b59e1645226d78d73282f45b326f7bddcb9"},
+    {file = "greenlet-2.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56961cfca7da2fdd178f95ca407fa330c64f33289e1804b592a77d5593d9bd94"},
+    {file = "greenlet-2.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13ba6e8e326e2116c954074c994da14954982ba2795aebb881c07ac5d093a58a"},
+    {file = "greenlet-2.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bf633a50cc93ed17e494015897361010fc08700d92676c87931d3ea464123ce"},
+    {file = "greenlet-2.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9f2c221eecb7ead00b8e3ddb913c67f75cba078fd1d326053225a3f59d850d72"},
+    {file = "greenlet-2.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:13ebf93c343dd8bd010cd98e617cb4c1c1f352a0cf2524c82d3814154116aa82"},
+    {file = "greenlet-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:6f61d71bbc9b4a3de768371b210d906726535d6ca43506737682caa754b956cd"},
+    {file = "greenlet-2.0.1-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:2d0bac0385d2b43a7bd1d651621a4e0f1380abc63d6fb1012213a401cbd5bf8f"},
+    {file = "greenlet-2.0.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:f6327b6907b4cb72f650a5b7b1be23a2aab395017aa6f1adb13069d66360eb3f"},
+    {file = "greenlet-2.0.1-cp35-cp35m-win32.whl", hash = "sha256:81b0ea3715bf6a848d6f7149d25bf018fd24554a4be01fcbbe3fdc78e890b955"},
+    {file = "greenlet-2.0.1-cp35-cp35m-win_amd64.whl", hash = "sha256:38255a3f1e8942573b067510f9611fc9e38196077b0c8eb7a8c795e105f9ce77"},
+    {file = "greenlet-2.0.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:04957dc96669be041e0c260964cfef4c77287f07c40452e61abe19d647505581"},
+    {file = "greenlet-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:4aeaebcd91d9fee9aa768c1b39cb12214b30bf36d2b7370505a9f2165fedd8d9"},
+    {file = "greenlet-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:974a39bdb8c90a85982cdb78a103a32e0b1be986d411303064b28a80611f6e51"},
+    {file = "greenlet-2.0.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dca09dedf1bd8684767bc736cc20c97c29bc0c04c413e3276e0962cd7aeb148"},
+    {file = "greenlet-2.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4c0757db9bd08470ff8277791795e70d0bf035a011a528ee9a5ce9454b6cba2"},
+    {file = "greenlet-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:5067920de254f1a2dee8d3d9d7e4e03718e8fd2d2d9db962c8c9fa781ae82a39"},
+    {file = "greenlet-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:5a8e05057fab2a365c81abc696cb753da7549d20266e8511eb6c9d9f72fe3e92"},
+    {file = "greenlet-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:3d75b8d013086b08e801fbbb896f7d5c9e6ccd44f13a9241d2bf7c0df9eda928"},
+    {file = "greenlet-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:097e3dae69321e9100202fc62977f687454cd0ea147d0fd5a766e57450c569fd"},
+    {file = "greenlet-2.0.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:cb242fc2cda5a307a7698c93173d3627a2a90d00507bccf5bc228851e8304963"},
+    {file = "greenlet-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:72b00a8e7c25dcea5946692a2485b1a0c0661ed93ecfedfa9b6687bd89a24ef5"},
+    {file = "greenlet-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5b0ff9878333823226d270417f24f4d06f235cb3e54d1103b71ea537a6a86ce"},
+    {file = "greenlet-2.0.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be9e0fb2ada7e5124f5282d6381903183ecc73ea019568d6d63d33f25b2a9000"},
+    {file = "greenlet-2.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b493db84d124805865adc587532ebad30efa68f79ad68f11b336e0a51ec86c2"},
+    {file = "greenlet-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0459d94f73265744fee4c2d5ec44c6f34aa8a31017e6e9de770f7bcf29710be9"},
+    {file = "greenlet-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a20d33124935d27b80e6fdacbd34205732660e0a1d35d8b10b3328179a2b51a1"},
+    {file = "greenlet-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:ea688d11707d30e212e0110a1aac7f7f3f542a259235d396f88be68b649e47d1"},
+    {file = "greenlet-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:afe07421c969e259e9403c3bb658968702bc3b78ec0b6fde3ae1e73440529c23"},
+    {file = "greenlet-2.0.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:cd4ccc364cf75d1422e66e247e52a93da6a9b73cefa8cad696f3cbbb75af179d"},
+    {file = "greenlet-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c8b1c43e75c42a6cafcc71defa9e01ead39ae80bd733a2608b297412beede68"},
+    {file = "greenlet-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:659f167f419a4609bc0516fb18ea69ed39dbb25594934bd2dd4d0401660e8a1e"},
+    {file = "greenlet-2.0.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:356e4519d4dfa766d50ecc498544b44c0249b6de66426041d7f8b751de4d6b48"},
+    {file = "greenlet-2.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:811e1d37d60b47cb8126e0a929b58c046251f28117cb16fcd371eed61f66b764"},
+    {file = "greenlet-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:d38ffd0e81ba8ef347d2be0772e899c289b59ff150ebbbbe05dc61b1246eb4e0"},
+    {file = "greenlet-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:0109af1138afbfb8ae647e31a2b1ab030f58b21dd8528c27beaeb0093b7938a9"},
+    {file = "greenlet-2.0.1-cp38-cp38-win32.whl", hash = "sha256:88c8d517e78acdf7df8a2134a3c4b964415b575d2840a2746ddb1cc6175f8608"},
+    {file = "greenlet-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:d6ee1aa7ab36475035eb48c01efae87d37936a8173fc4d7b10bb02c2d75dd8f6"},
+    {file = "greenlet-2.0.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:b1992ba9d4780d9af9726bbcef6a1db12d9ab1ccc35e5773685a24b7fb2758eb"},
+    {file = "greenlet-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:b5e83e4de81dcc9425598d9469a624826a0b1211380ac444c7c791d4a2137c19"},
+    {file = "greenlet-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:505138d4fa69462447a562a7c2ef723c6025ba12ac04478bc1ce2fcc279a2db5"},
+    {file = "greenlet-2.0.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cce1e90dd302f45716a7715517c6aa0468af0bf38e814ad4eab58e88fc09f7f7"},
+    {file = "greenlet-2.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e9744c657d896c7b580455e739899e492a4a452e2dd4d2b3e459f6b244a638d"},
+    {file = "greenlet-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:662e8f7cad915ba75d8017b3e601afc01ef20deeeabf281bd00369de196d7726"},
+    {file = "greenlet-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:41b825d65f31e394b523c84db84f9383a2f7eefc13d987f308f4663794d2687e"},
+    {file = "greenlet-2.0.1-cp39-cp39-win32.whl", hash = "sha256:db38f80540083ea33bdab614a9d28bcec4b54daa5aff1668d7827a9fc769ae0a"},
+    {file = "greenlet-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b23d2a46d53210b498e5b701a1913697671988f4bf8e10f935433f6e7c332fb6"},
+    {file = "greenlet-2.0.1.tar.gz", hash = "sha256:42e602564460da0e8ee67cb6d7236363ee5e131aa15943b6670e44e5c2ed0f67"},
 ]
 h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ httptools = "^0.3.0"
 python-multipart = "^0.0.5"
 aiofiles = "^0.8.0"
 fastapi-users = {extras = ["sqlalchemy", "oauth"], version = "^10.1.5"}
+asyncssh = "^2.12.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ python-multipart = "^0.0.5"
 aiofiles = "^0.8.0"
 fastapi-users = {extras = ["sqlalchemy", "oauth"], version = "^10.1.5"}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
 flake8 = "^4.0.1"
 mypy = "^0.961"
@@ -41,6 +41,7 @@ anyio = "^3.6.1"
 pytest-env = "^0.6.2"
 httpx = "^0.22.0"
 types-aiofiles = "^0.8.11"
+testcontainers = "^3.7.0"
 
 [tool.poetry.scripts]
 bartender = 'bartender.__main__:main'


### PR DESCRIPTION
Adds Slurm scheduler support. 

Also adds
* sftp file system to copy input/output to/from a remote Slurm server.
* Testing against slurm is done using a Docker container. using https://github.com/testcontainers/testcontainers-python (fixes #12)
* Disable more flake8 rules which are false positives or not valid in tests.

To test spin up a Slurm container with
```shell
docker run --detach --publish 10022:22 xenonmiddleware/slurm:20
```

To submit a job in a Python REPL (`python -m asyncio` or `ipython`)

```python
from pathlib import Path
from bartender.filesystems.sftp import SftpFileSystem
from bartender.schedulers.abstract import JobDescription
from bartender.schedulers.slurm import SlurmScheduler
from bartender.schedulers.runner import SshCommandRunner

job_dir = Path('/tmp/jobs/myjob')
job_dir.mkdir(parents=True, exist_ok=True)
config = {
            "hostname": 'localhost',
            "port": 10022,
            "username": 'xenon',
            "password": 'javagat',
        }
scheduler = SlurmScheduler(runner=SshCommandRunner(config))
description = JobDescription(command="echo -n hello", job_dir=str(job_dir))
fs = SftpFileSystem(entry='/home/xenon', config=config)
localized_description = fs.localize_description(description, job_dir.parent)

await fs.upload(description, localized_description)

job_id = await scheduler.submit(localized_description)

print(await scheduler.state(job_id))
# Repeat fetching state until it is 'ok' or 'error'

await fs.download(localized_description, description)
```
After download should have stderr.txt, stdout.txt, returncode files in /tmp/jobs/myjob.


As similar job submission is done at https://github.com/i-VRESSE/bartender/blob/slurm-scheduler/bartender/tests/schedulers/test_slurm.py#L60

Don't forget to `docker rm -f <slurm container name or id>` when you are done.
