### PR TITLE
Download job output

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -66,6 +66,18 @@ test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+
+[[package]]
 name = "arq"
 version = "0.25.0"
 description = "Job queues in python with asyncio and redis"
@@ -1134,6 +1146,26 @@ files = [
 
 [package.dependencies]
 flake8 = "*"
+
+[[package]]
+name = "fs"
+version = "2.4.16"
+description = "Python's filesystem abstraction layer"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "fs-2.4.16-py2.py3-none-any.whl", hash = "sha256:660064febbccda264ae0b6bace80a8d1be9e089e0a5eb2427b7d517f9a91545c"},
+    {file = "fs-2.4.16.tar.gz", hash = "sha256:ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313"},
+]
+
+[package.dependencies]
+appdirs = ">=1.4.3,<1.5.0"
+setuptools = "*"
+six = ">=1.10,<2.0"
+
+[package.extras]
+scandir = ["scandir (>=1.5,<2.0)"]
 
 [[package]]
 name = "furo"
@@ -2509,7 +2541,7 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 name = "setuptools"
 version = "67.6.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2521,6 +2553,18 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 
 [[package]]
 name = "smmap"
@@ -3549,4 +3593,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5e47ed4e0afd77334943497939877f98ab02c1aac9d6e95228e78bf515200502"
+content-hash = "5648af52fc879c27c0a210ca0c319a35c793b8057fadacedd2851f4652a6dabe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ fastapi-users = {extras = ["oauth", "sqlalchemy"], version = "^10.4.1"}
 asyncssh = "^2.13.1"
 pyyaml = "^6.0"
 arq = "^0.25.0"
+fs = "^2.4.16"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -338,7 +338,7 @@ async def retrieve_job_directory_as_archive(
 
     background_tasks.add_task(_remove_archive, archive_fn)
 
-    return_fn = str(Path(archive_fn).name)
+    return_fn = Path(archive_fn).name
     return FileResponse(archive_fn, filename=return_fn)
 
 

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -324,7 +324,7 @@ async def retrieve_job_directory_as_archive(
         FileResponse: Archive containing the content of job_dir
 
     """
-    dst_fs = _parse_archive_fmt(archive_format)
+    dst_fs = _parse_archive_format(archive_format)
     archive_fn = str(job_dir.with_suffix(archive_format))
     with (  # noqa: WPS316
         OSFS(str(job_dir)) as src,
@@ -342,8 +342,8 @@ async def retrieve_job_directory_as_archive(
     return FileResponse(archive_fn, filename=return_fn)
 
 
-def _parse_archive_fmt(archive_fmt: str) -> Union[Type[ZipFS], Type[TarFS]]:
-    if archive_fmt == ".zip":
+def _parse_archive_format(archive_format: str) -> Union[Type[ZipFS], Type[TarFS]]:
+    if archive_format == ".zip":
         return ZipFS
     return TarFS
 

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -299,7 +299,7 @@ async def retrieve_job_directory_as_archive(
         background_tasks: FastAPI mechanism for post-processing tasks
 
     Returns:
-        FileResponse: Zipfile containing the output of job_dir
+        FileResponse: Zipfile containing the content of job_dir
 
     """
     archive_fn = Path(job_dir).parent / Path(job_dir).name
@@ -313,3 +313,22 @@ async def retrieve_job_directory_as_archive(
     background_tasks.add_task(_remove_archive, filename)
 
     return FileResponse(filename, filename=Path(filename).name)
+
+
+@router.get("/{jobid}/archive/output")
+async def retrieve_job_output_as_archive(
+    job_dir: CurrentCompletedJobDir,
+    background_tasks: BackgroundTasks,
+) -> FileResponse:
+    """Download job output as archive.
+
+    Args:
+        job_dir: The job directory.
+        background_tasks: FastAPI mechanism for post-processing tasks
+
+    Returns:
+        FileResponse: Zipfile containing the output of job_dir
+
+    """
+    job_output_dir = str(Path(job_dir) / "output")
+    return await retrieve_job_directory_as_archive(job_output_dir, background_tasks)

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -342,7 +342,7 @@ async def retrieve_job_directory_as_archive(
     return FileResponse(archive_fn, filename=return_fn)
 
 
-def _parse_archive_format(archive_format: str) -> Union[Type[ZipFS], Type[TarFS]]:
+def _parse_archive_format(archive_format: ArchiveFormats) -> Union[Type[ZipFS], Type[TarFS]]:
     if archive_format == ".zip":
         return ZipFS
     return TarFS

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -12,6 +12,7 @@ from pydantic import PositiveInt
 from sqlalchemy.exc import NoResultFound
 from starlette import status
 
+from bartender.async_utils import async_wrap
 from bartender.context import CurrentContext, get_job_root_dir
 from bartender.db.dao.job_dao import CurrentJobDAO
 from bartender.db.models.job_model import CompletedStates, Job
@@ -329,7 +330,11 @@ async def retrieve_job_directory_as_archive(
         OSFS(str(job_dir)) as src,
         dst_fs(archive_fn, write=True) as dst,
     ):
-        copy_fs(src, dst, walker=Walker(exclude=exclude, exclude_dirs=exclude_dirs))
+        await async_wrap(copy_fs)(
+            src,
+            dst,
+            walker=Walker(exclude=exclude, exclude_dirs=exclude_dirs),
+        )
 
     background_tasks.add_task(_remove_archive, archive_fn)
 

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -290,7 +290,10 @@ def _remove_archive(filename: str) -> None:
     Path(filename).unlink()
 
 
-@router.get("/{jobid}/archive")
+@router.get(
+    "/{jobid}/archive",
+    responses={200: {"content": {"application/octet-stream": {}}}},
+)
 async def retrieve_job_directory_as_archive(
     job_dir: CurrentCompletedJobDir,
     background_tasks: BackgroundTasks,

--- a/tests/web/test_job.py
+++ b/tests/web/test_job.py
@@ -551,6 +551,12 @@ async def test_directories(
         "is_file": False,
         "children": [
             {
+                "is_dir": True,
+                "is_file": False,
+                "name": "output",
+                "path": "output",
+            },
+            {
                 "is_dir": False,
                 "is_file": True,
                 "name": "somefile.txt",

--- a/tests/web/test_job.py
+++ b/tests/web/test_job.py
@@ -607,7 +607,7 @@ async def test_directories_from_path(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "archive_fmt",
+    "archive_format",
     [".zip", ".tar", ".tar.xz", ".tar.gz", ".tar.bz2"],
 )
 async def test_job_directory_as_archive(
@@ -615,21 +615,23 @@ async def test_job_directory_as_archive(
     client: AsyncClient,
     auth_headers: Dict[str, str],
     mock_ok_job: int,
-    archive_fmt: str,
+    archive_format: str,
 ) -> None:
     url = (
         fastapi_app.url_path_for(
             "retrieve_job_directory_as_archive",
             jobid=mock_ok_job,
         )
-        + f"?archive_fmt={archive_fmt}"
+        + f"?archive_format={archive_format}"
     )
     response = await client.get(url, headers=auth_headers)
 
     expected_content_type = (
-        "application/zip" if archive_fmt == ".zip" else "application/x-tar"
+        "application/zip" if archive_format == ".zip" else "application/x-tar"
     )
-    expected_content_disposition = f'attachment; filename="{mock_ok_job}{archive_fmt}"'
+    expected_content_disposition = (
+        f'attachment; filename="{mock_ok_job}{archive_format}"'
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.headers["content-type"] == expected_content_type


### PR DESCRIPTION
Add endpoint for downloading contents of job folder as archive.

To do:

- [x] allow different archive formats
- [x] exclude input/output/stdout/stderr
- [x] cleanup archive after download

To test:
- Try the archive endpoint on http://127.0.0.1:8000/api/docs#/job/retrieve_job_stdout

refs #66