### PR TITLE
Dirac test fail 71

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,9 +62,8 @@ repos:
     name: Check with Flake8
     entry: poetry run flake8
     language: system
-    pass_filenames: false
     types: [python]
-    args: [--count, .]
+    args: [--count]
 
   - id: mypy
     name: Validate types with MyPy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,16 +254,12 @@ If you need [DIRAC](http://diracgrid.org/) support create a conda environment
 instead of creating a virtual environment.
 
 ```bash
-mamba create --name bartender dirac-grid python=3.10
+mamba create --name bartender dirac-grid python=3.10 poetry=1.5.1
 conda activate bartender
+poetry install
 ```
 
-The conda environment contains all DIRAC dependencies.
-Install DIRAC itself with
-
-```bash
-pip install DIRAC==8.0
-```
+The conda environment contains all DIRAC dependencies and DIRAC itself.
 
 (Cannot use `poetry install --with=dirac` as Poetry gets stuck resolving
 dependencies because it ignores the already installed DIRAC dependencies.)

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -213,3 +213,11 @@ do this outside container with
 docker compose -f tests_dirac/docker-compose.yml rm -fs dirac-tuto
 docker compose -f tests_dirac/docker-compose.yml up dirac-tuto
 ```
+
+When the DIRAC server container is running you can login to it with
+
+```shell
+docker exec -ti <constainer id or name> bash
+. bashrc
+dirac-proxy-init -K ~diracuser/.globus/userkey.pem -C ~diracuser/.globus/usercert.pem
+```

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -217,7 +217,18 @@ docker compose -f tests_dirac/docker-compose.yml up dirac-tuto
 When the DIRAC server container is running you can login to it with
 
 ```shell
-docker exec -ti <constainer id or name> bash
+docker exec -ti tests_dirac-dirac-tuto-1 bash
 . bashrc
 dirac-proxy-init -K ~diracuser/.globus/userkey.pem -C ~diracuser/.globus/usercert.pem
+# to fetch job status
+dirac-wms-job-status 1
+dirac-wms-job-logging-info 1
+# to download raw logs
+dirac-wms-job-get-output 1
+# to download output files
+dirac-wms-job-get-output-data 1
+# to browse storage
+dirac-dms-filecatalog-cli
+# pilot logs
+cat ~diracpilot/localsite/output/*
 ```

--- a/src/bartender/filesystems/dirac.py
+++ b/src/bartender/filesystems/dirac.py
@@ -108,6 +108,9 @@ class DiracFileSystem(AbstractFileSystem):
             if not result["OK"]:
                 raise RuntimeError(result["Message"])
             archive_fn_in_tmpdir = Path(tmpdirname) / archive_base_fn
+            if not archive_fn_in_tmpdir.exists():
+                # Failed job does not have a output.tar
+                return
             # TODO what happens if file in job_dir already exists?
             logger.warning(f"Unpacking {archive_fn_in_tmpdir} to {target.job_dir}")
             await async_wrap(unpack_archive)(archive_fn_in_tmpdir, target.job_dir)

--- a/src/bartender/filesystems/dirac_config.py
+++ b/src/bartender/filesystems/dirac_config.py
@@ -10,9 +10,10 @@ class DiracFileSystemConfig(BaseModel):
     """Configuration for DIRAC file system.
 
     Args:
-        lfn_root: Location on grid storage where files of jobs can be stored. Used to
-            localize description.
-            To stage output files the root should be located within the user's home directory.
+        lfn_root: Location on grid storage where files of jobs can be stored.
+            Used to localize description.
+            To stage output files the root should be located within
+            the user's home directory.
             Home directory is formatted like `/<VO>/user/<initial>/<username>`.
         storage_element: Storage element for lfn_root.
         proxy: Proxy configuration.
@@ -24,10 +25,14 @@ class DiracFileSystemConfig(BaseModel):
     proxy: ProxyConfig = ProxyConfig()
 
     @validator("lfn_root")
-    def _validate_lfn_root(cls, v: str) -> str:
+    def _validate_lfn_root(
+        cls,  # noqa: N805 signature of validator
+        v: str,  # noqa: WPS111 signature of validator
+    ) -> str:
         pattern = r"^\/\w+\/user\/([a-zA-Z])\/\1\w+\/.*$"
         if not re.match(pattern, v):
+            template = "/<VO>/user/<initial>/<username>/<whatever>"
             raise ValueError(
-                f"{v} should match the format `/<VO>/user/<initial>/<username>/<whatever>`",
+                f"{v} should match the format `{template}`",
             )
         return v

--- a/src/bartender/filesystems/dirac_config.py
+++ b/src/bartender/filesystems/dirac_config.py
@@ -1,6 +1,7 @@
+import re
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from bartender.shared.dirac_config import ProxyConfig
 
@@ -10,7 +11,9 @@ class DiracFileSystemConfig(BaseModel):
 
     Args:
         lfn_root: Location on grid storage where files of jobs can be stored. Used to
-            localize description.
+            localize description. 
+            To stage output files the root should be located within the user's home directory.
+            Home directory is formatted like `/<VO>/user/<initial>/<username>`.
         storage_element: Storage element for lfn_root.
         proxy: Proxy configuration.
     """
@@ -19,3 +22,10 @@ class DiracFileSystemConfig(BaseModel):
     lfn_root: str
     storage_element: str
     proxy: ProxyConfig = ProxyConfig()
+
+    @validator('lfn_root')
+    def _validate_lfn_root(cls, v):
+        pattern = r'^\/\w+\/user\/([a-zA-Z])\/\1\w+\/.*$'
+        if not re.match(pattern, v):
+            raise ValueError(f"{v} should match the format `/<VO>/user/<initial>/<username>/<whatever>`")
+        return v

--- a/src/bartender/filesystems/dirac_config.py
+++ b/src/bartender/filesystems/dirac_config.py
@@ -11,7 +11,7 @@ class DiracFileSystemConfig(BaseModel):
 
     Args:
         lfn_root: Location on grid storage where files of jobs can be stored. Used to
-            localize description. 
+            localize description.
             To stage output files the root should be located within the user's home directory.
             Home directory is formatted like `/<VO>/user/<initial>/<username>`.
         storage_element: Storage element for lfn_root.
@@ -23,9 +23,11 @@ class DiracFileSystemConfig(BaseModel):
     storage_element: str
     proxy: ProxyConfig = ProxyConfig()
 
-    @validator('lfn_root')
-    def _validate_lfn_root(cls, v):
-        pattern = r'^\/\w+\/user\/([a-zA-Z])\/\1\w+\/.*$'
+    @validator("lfn_root")
+    def _validate_lfn_root(cls, v: str) -> str:
+        pattern = r"^\/\w+\/user\/([a-zA-Z])\/\1\w+\/.*$"
         if not re.match(pattern, v):
-            raise ValueError(f"{v} should match the format `/<VO>/user/<initial>/<username>/<whatever>`")
+            raise ValueError(
+                f"{v} should match the format `/<VO>/user/<initial>/<username>/<whatever>`",
+            )
         return v

--- a/src/bartender/schedulers/abstract.py
+++ b/src/bartender/schedulers/abstract.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 from types import TracebackType
-from typing import Optional, Type
+from typing import Optional, Tuple, Type
 
+import aiofiles
 from pydantic import BaseModel
 
 from bartender.db.models.job_model import State
@@ -74,6 +75,22 @@ class AbstractScheduler(ABC):
         Args:
             job_id: Identifier of job.
         """
+
+    async def logs(self, job_id: str, job_dir: Path) -> Tuple[str, str]:
+        """Get stdout and stderr of a job.
+
+        Args:
+            job_id: Identifier of job.
+            job_dir: Directory where job input and output are stored.
+
+        Returns:
+            Tuple of stdout and stderr.
+        """
+        async with aiofiles.open(job_dir / "stdout.txt", mode="r") as fout:
+            stdout = await fout.read()
+        async with aiofiles.open(job_dir / "stderr.txt", mode="r") as ferr:
+            stderr = await ferr.read()
+        return stdout, stderr
 
     async def __aenter__(self) -> "AbstractScheduler":
         return self

--- a/src/bartender/schedulers/abstract.py
+++ b/src/bartender/schedulers/abstract.py
@@ -79,9 +79,13 @@ class AbstractScheduler(ABC):
     async def logs(self, job_id: str, job_dir: Path) -> Tuple[str, str]:
         """Get stdout and stderr of a job.
 
+        If job has not completed, then will raise an exception.
+        If job completed, then stdout,txt and stderr.txt are read from job_dir.
+
         Args:
             job_id: Identifier of job.
-            job_dir: Directory where job input and output are stored.
+            job_dir: Directory where stdout.txt and stderr.txt files
+                of job are stored.
 
         Returns:
             Tuple of stdout and stderr.

--- a/src/bartender/schedulers/dirac.py
+++ b/src/bartender/schedulers/dirac.py
@@ -193,7 +193,7 @@ class DiracScheduler(AbstractScheduler):
             RuntimeError: When fetching of logs fails.
 
         Returns:
-            stdout and stderr of raw job.
+            Tuple of stdout and stderr.
         """
         try:
             return await super().logs(job_id, job_dir)

--- a/src/bartender/schedulers/dirac.py
+++ b/src/bartender/schedulers/dirac.py
@@ -230,7 +230,9 @@ class DiracScheduler(AbstractScheduler):
         # TODO when command has non-zero return code then
         # output.tar is not uploaded,
         # you can get logs with scheduduler.raw_logs()
-        # but output.tar is gone
+        # but output.tar is gone, wouild be nice to have it
+        # see possible options at
+        # https://github.com/i-VRESSE/bartender/pull/72
         return dedent(
             f"""\
             #!/bin/bash
@@ -259,6 +261,8 @@ class DiracScheduler(AbstractScheduler):
         # is not uploaded and uploading output.tar fails due to
         # UnboundLocalError: local variable 'result_sbUpload'
 
+        # added cat of stdout.txt and stderr.txt
+        # so if job fails then logs are available in output sandbox.
         return dedent(
             f"""\
             # Run command
@@ -280,7 +284,7 @@ class DiracScheduler(AbstractScheduler):
 
         # OutputPath must be relative to user's home directory
         # to prevent files being uploaded outside user's home directory.
-        output_path = self._relative_output_dir(description)
+        output_path = _relative_output_dir(description)
         return dedent(
             f"""\
             JobName = "{job_name}";
@@ -298,21 +302,22 @@ class DiracScheduler(AbstractScheduler):
             """,  # noqa: E501, WPS237
         )
 
-    def _relative_output_dir(self, description: JobDescription) -> Path:
-        """Return description.output_dir relative to user's home directory.
 
-        user home directory is /<vo>/user/<initial>/<user>
-        to write /tutoVO/user/c/ciuser/bartenderjobs/job1/input.tar
-        OutputPath must be bartenderjobs/job1
+def _relative_output_dir(description: JobDescription) -> Path:
+    """Return description.output_dir relative to user's home directory.
 
-        Args:
-            description: Description of job.
+    user home directory is /<vo>/user/<initial>/<user>
+    to write /tutoVO/user/c/ciuser/bartenderjobs/job1/input.tar
+    OutputPath must be bartenderjobs/job1
 
-        Returns:
-            .description.output_dir relative to user's home directory.
-        """
-        home_dir = Path(*description.job_dir.parts[:5])
-        return description.job_dir.relative_to(home_dir)
+    Args:
+        description: Description of job.
+
+    Returns:
+        .description.output_dir relative to user's home directory.
+    """
+    nr_home_dir_parts = 5
+    return Path(*description.job_dir.parts[nr_home_dir_parts:])
 
 
 async def _extract_text_file(tar: tarfile.TarFile, name: str) -> str:

--- a/src/bartender/schedulers/dirac.py
+++ b/src/bartender/schedulers/dirac.py
@@ -171,17 +171,23 @@ class DiracScheduler(AbstractScheduler):
         await teardown_proxy_renewer()
 
     async def logs(self, job_id: str, job_dir: Path) -> Tuple[str, str]:
-        """Return logs of raw job.
+        """Get stdout and stderr of a job.
 
-        Includes logs of unpacking/packing the input and output.
-        While logs in job_dir only include logs of execution of command.
+        If job has not completed, then will raise an exception.
+        If job completed succesfully, then stdout,txt and stderr.txt are read
+        from job_dir.
+        If job failed, then stdout and stderr are read from grid storage.
 
-        The jobstdout.txt and jobstderr.txt can be fetched on command line
+        Logs of a failed job includes logs of unpacking/packing the
+        input and output files.
+
+        The logs can be fetched on command line
         with `dirac-wms-job-get-output <job id>`.
 
         Args:
             job_id: Identifier of job.
-            job_dir: Directory where ok job has its logs.
+            job_dir: Directory where stdout.txt and stderr.txt files
+                of job are stored.
 
         Raises:
             RuntimeError: When fetching of logs fails.

--- a/src/bartender/schedulers/dirac.py
+++ b/src/bartender/schedulers/dirac.py
@@ -182,10 +182,10 @@ class DiracScheduler(AbstractScheduler):
         return dedent(
             f"""\
             #!/bin/bash
-            set -e
             {stage_in}
             {command}
             {stage_out}
+            exit $(cat returncode)
             """,
         )
 
@@ -234,8 +234,7 @@ class DiracScheduler(AbstractScheduler):
         # tried but got
         # `JobWrapperError: No output SEs defined in VO configuration` error
 
-
-        # OutputPath must be relative to user's home directory 
+        # OutputPath must be relative to user's home directory
         # to prevent files being uploaded outside user's home directory.
         output_path = self._relative_output_dir(description)
         return dedent(
@@ -257,7 +256,7 @@ class DiracScheduler(AbstractScheduler):
 
     def _relative_output_dir(self, description: JobDescription) -> Path:
         """Return description.output_dir relative to user's home directory.
-        
+
         user home directory is /<vo>/user/<initial>/<user>
         to write /tutoVO/user/c/ciuser/bartenderjobs/job1/input.tar
         OutputPath must be bartenderjobs/job1

--- a/tests/web/test_job.py
+++ b/tests/web/test_job.py
@@ -505,7 +505,6 @@ async def test_stdout(
     assert response.status_code == status.HTTP_200_OK
     assert response.text == "this is stdout"
     assert response.headers["content-type"] == "text/plain; charset=utf-8"
-    assert response.headers["content-disposition"] == 'inline; filename="stdout.txt"'
 
 
 @pytest.mark.anyio
@@ -522,7 +521,6 @@ async def test_stderr(
     assert response.status_code == status.HTTP_200_OK
     assert response.text == "this is stderr"
     assert response.headers["content-type"] == "text/plain; charset=utf-8"
-    assert response.headers["content-disposition"] == 'inline; filename="stderr.txt"'
 
 
 @pytest.mark.anyio

--- a/tests_dirac/Dockerfile
+++ b/tests_dirac/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/xenon-middleware/diracclient:8.0.18
 
-RUN pip install poetry==1.4.2
+RUN pip install poetry==1.5.1
 
 # Configuring poetry
 RUN poetry config virtualenvs.create false

--- a/tests_dirac/Dockerfile
+++ b/tests_dirac/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/xenon-middleware/diracclient:8.0.18
 
-RUN pip install poetry==1.5.1
+RUN pip install poetry==1.5.1 && \
+    pip install --upgrade pip wheel setuptools
 
 # Configuring poetry
 RUN poetry config virtualenvs.create false

--- a/tests_dirac/test_it.py
+++ b/tests_dirac/test_it.py
@@ -237,7 +237,7 @@ async def test_failing_job(  # noqa: WPS217 single piece of code for readablilty
 
         await wait_for_job(scheduler, job_id, expected="error")
 
-        stdout, stderr = scheduler.raw_logs(job_id)
+        stdout, stderr = await scheduler.raw_logs(job_id)
 
         assert "icannotwork" in stdout
         assert "idonotexist" in stderr

--- a/tests_dirac/test_it.py
+++ b/tests_dirac/test_it.py
@@ -241,6 +241,11 @@ async def test_failing_job(  # noqa: WPS217 single piece of code for readablilty
 
         assert "icannotwork" in stdout
         assert "idonotexist" in stderr
+
+        await fs.download(gdescription, description)
+        files_in_job_dir = list(job_dir.iterdir())
+        # stdout.txt and stderr.txt, which is side effect of logs()
+        assert len(files_in_job_dir) == 2
     finally:
         # So next time the test does not complain about existing files
         await fs.delete(gdescription)

--- a/tests_dirac/test_it.py
+++ b/tests_dirac/test_it.py
@@ -237,7 +237,7 @@ async def test_failing_job(  # noqa: WPS217 single piece of code for readablilty
 
         await wait_for_job(scheduler, job_id, expected="error")
 
-        stdout, stderr = await scheduler.raw_logs(job_id)
+        stdout, stderr = await scheduler.logs(job_id, description.job_dir)
 
         assert "icannotwork" in stdout
         assert "idonotexist" in stderr

--- a/tests_dirac/test_it.py
+++ b/tests_dirac/test_it.py
@@ -14,7 +14,7 @@ from bartender.shared.ssh import SshConnectConfig
 def prepare_input(job_dir: Path) -> JobDescription:
     (job_dir / "input").write_text("Lorem ipsum")
     return JobDescription(
-        command="echo -n hello && mkdir output && wc input > output/output.txt",
+        command="echo -n hello && mkdir -p output && wc input > output/output.txt",
         job_dir=job_dir,
     )
 
@@ -204,5 +204,45 @@ async def test_states_and_cancel(tmp_path: Path) -> None:  # noqa: WPS217 readab
     finally:
         # So next time the test does not complain about existing files
         await fs.delete(gdescription)
+        await fs.close()
+        await scheduler.close()
+
+
+@pytest.mark.anyio
+async def test_failing_job(  # noqa: WPS217 single piece of code for readablilty
+    tmp_path: Path,
+) -> None:
+    fs_config = DiracFileSystemConfig(
+        lfn_root="/tutoVO/user/c/ciuser/bartenderjobs",
+        storage_element="StorageElementOne",
+    )
+    fs = DiracFileSystem(fs_config)
+    sched_config = DiracSchedulerConfig(storage_element=fs_config.storage_element)
+    scheduler = DiracScheduler(sched_config)
+    # emulate external job id with job1 subdir
+    # job_dir.name is used as directory to upload inputfiles to lfn_root
+    job_dir = tmp_path / "job3"
+    job_dir.mkdir()
+    description = JobDescription(
+        command="echo icannotwork && exit 42",
+        job_dir=job_dir,
+    )
+    gdescription = fs.localize_description(description, tmp_path)
+    try:
+        await fs.upload(description, gdescription)
+
+        job_id = await scheduler.submit(gdescription)
+
+        assert job_id
+
+        await wait_for_job(scheduler, job_id, expected="error")
+
+        await fs.download(gdescription, description)
+
+        assert "icannotwork" in (job_dir / "stdout.txt").read_text()
+        assert (job_dir / "returncode").read_text() == "42"
+    finally:
+        # So next time the test does not complain about existing files
+        # await fs.delete(gdescription)
         await fs.close()
         await scheduler.close()


### PR DESCRIPTION
Fixes #71

When a job submitted to the DIRAC scheduler fails then logs of it can be requested with `/job//{jobid}/stdout` 
 and `/job//{jobid}/stderr` endpoints.

The input.tar and output.tar are now staged by [job description language](https://dirac.readthedocs.io/en/latest/UserGuide/GettingStarted/UserJobs/JDLReference/index.html) aka jdl
