### PR TITLE
Static app routes

### DIFF
--- a/config-haddock3.yaml
+++ b/config-haddock3.yaml
@@ -35,7 +35,6 @@ interactive_applications:
     description: Rescore a HADDOCK run with different weights.
     job_application: haddock3
     input_schema:
-      $schema: https://json-schema.org/draft/2020-12/schema
       additionalProperties: false
       properties:
         capri_dir:
@@ -73,7 +72,6 @@ interactive_applications:
     description: Recluster a HADDOCK run with RSMD and different parameters.
     job_application: haddock3
     input_schema:
-      $schema: https://json-schema.org/draft/2020-12/schema
       additionalProperties: false
       properties:
         clustrmsd_dir:
@@ -99,7 +97,6 @@ interactive_applications:
     description: Recluster a HADDOCK run with FCC and different parameters.
     job_application: haddock3
     input_schema:
-      $schema: https://json-schema.org/draft/2020-12/schema
       additionalProperties: false
       properties:
         clustfcc_dir:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -438,7 +438,6 @@ interactive_applications:
         description: Rescore a HADDOCK run with different weights.
         job_application: haddock3
         input_schema:
-            $schema: https://json-schema.org/draft/2020-12/schema
             additionalProperties: false
             properties:
                 capri_dir:

--- a/src/bartender/config.py
+++ b/src/bartender/config.py
@@ -326,7 +326,7 @@ def unroll_application_route(
     }
     return {
         "tags": ["application"],
-        "operationId": aname,
+        "operationId": f"upload_{aname}",
         "summary": f"Upload job to {aname}",
         "requestBody": request_body,
         "responses": existing_put_path["responses"],

--- a/src/bartender/config.py
+++ b/src/bartender/config.py
@@ -317,7 +317,7 @@ def unroll_application_route(
                 # does not seem supported by Swagger UI or FastAPI
                 "encoding": {
                     "upload": {
-                        "contentType": "application/zip",
+                        "contentType": "application/zip, application/x-zip-compressed",
                     },
                 },
             },

--- a/src/bartender/config.py
+++ b/src/bartender/config.py
@@ -310,13 +310,14 @@ def unroll_application_route(
                     },
                     "type": "object",
                     "required": ["upload"],
+                    "title": f"Upload {aname}",
                 },
                 # Enfore uploaded file is a certain content type
                 # See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encoding-object  # noqa: E501
                 # does not seem supported by Swagger UI or FastAPI
                 "encoding": {
                     "upload": {
-                        "contentType": "application/zip, application/x-zip-compressed",
+                        "contentType": "application/zip",
                     },
                 },
             },

--- a/src/bartender/config.py
+++ b/src/bartender/config.py
@@ -326,7 +326,7 @@ def unroll_application_route(
     }
     return {
         "tags": ["application"],
-        "operationId": f"upload_{aname}",
+        "operationId": f"application_{aname}",
         "summary": f"Upload job to {aname}",
         "requestBody": request_body,
         "responses": existing_put_path["responses"],
@@ -353,13 +353,13 @@ def unroll_interactive_app_routes(
         path = f"/api/job/{{jobid}}/interactive/{iname}"
         post = {
             "tags": ["interactive"],
-            "operationId": iname,
+            "operationId": f"interactive_application_{iname}",
             "parameters": [
                 {
                     "name": "jobid",
                     "in": "path",
                     "required": True,
-                    "schema": {"type": "string"},
+                    "schema": {"type": "number"},
                 },
             ],
             "requestBody": {

--- a/src/bartender/filesystem/__init__.py
+++ b/src/bartender/filesystem/__init__.py
@@ -27,7 +27,7 @@ def has_config_file(
     has = job_config.exists() and job_config.is_file()
     if not has:
         raise IndexError(
-            f"Application requires config file called ${app_config}, "
+            f"Application requires config file called {app_config}, "
             "but was not found in upload",
         )
     return has

--- a/src/bartender/web/api/applications/views.py
+++ b/src/bartender/web/api/applications/views.py
@@ -3,7 +3,6 @@ from fastapi.responses import RedirectResponse
 from starlette import status
 from starlette.background import BackgroundTask
 
-from bartender.config import ApplicatonConfiguration, CurrentConfig
 from bartender.context import Context, CurrentContext
 from bartender.db.dao.job_dao import CurrentJobDAO
 from bartender.filesystem import has_config_file
@@ -15,51 +14,9 @@ from bartender.web.users import CurrentUser, User
 router = APIRouter()
 
 
-@router.get("/")
-def list_applications(config: CurrentConfig) -> list[str]:
-    """List application names.
-
-    Args:
-        config: Config with applications.
-
-    Returns:
-        The list.
-    """
-    return list(config.applications.keys())
-
-
-@router.get("/{application}")
-def get_application(
-    application: str,
-    config: CurrentConfig,
-) -> ApplicatonConfiguration:
-    """Retrieve application configuration.
-
-    Args:
-        application: Name of application
-        config: Config with applications.
-
-    Returns:
-        The application config.
-    """
-    return config.applications[application]
-
-
 @router.put(
-    "/{application}/job",
+    "/{application}",
     status_code=status.HTTP_307_TEMPORARY_REDIRECT,
-    openapi_extra={
-        # Enfore uploaded file is a certain content type
-        # See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encoding-object  # noqa: E501
-        # does not seem supported by Swagger UI or FastAPI
-        "requestBody": {
-            "content": {
-                "multipart/form-data": {
-                    "encoding": {"upload": {"contentType": "application/zip"}},
-                },
-            },
-        },
-    },
 )
 async def upload_job(  # noqa: WPS211
     application: str,

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -420,33 +420,14 @@ def _parse_subdirectory(path: str, job_dir: Path) -> Path:
     return subdirectory
 
 
-@router.get("/{jobid}/interactive")
-def list_interactive_apps(jobid: int, config: CurrentConfig) -> list[str]:
-    """List interactive apps that can be run on a completed job.
-
-    Args:
-        config: The bartender configuration.
-        jobid: The job identifier.
-            It is not used, but there for consistency.
-
-    Returns:
-        List of interactive apps.
-    """
-    return list(config.interactive_applications.keys())
-
-
-@router.get("/{jobid}/interactive/{application}", response_model_exclude_defaults=True)
 def get_interactive_app(
     application: str,
-    jobid: int,
     config: CurrentConfig,
 ) -> InteractiveApplicationConfiguration:
     """Get interactive app configuration.
 
     Args:
         application: The interactive application.
-        jobid: The job identifier.
-            It is not used, but there for consistency.
         config: The bartender configuration.
 
     Returns:
@@ -464,20 +445,6 @@ CurrentInteractiveAppConf = Annotated[
 
 @router.post(
     "/{jobid}/interactive/{application}",
-    openapi_extra={
-        "requestBody": {
-            "content": {
-                "application/json": {
-                    "schema": {
-                        "type": "object",
-                        # As we pick application with path parameter,
-                        # we can't show schema of application here.
-                        # So we just show minimal schema.
-                    },
-                },
-            },
-        },
-    },
 )
 async def run_interactive_app(
     request: Request,

--- a/src/bartender/web/api/job/views.py
+++ b/src/bartender/web/api/job/views.py
@@ -161,7 +161,17 @@ def get_dir_of_completed_job(
 CurrentCompletedJobDir = Annotated[Path, Depends(get_dir_of_completed_job)]
 
 
-@router.get("/{jobid}/files/{path:path}")
+@router.get(
+    "/{jobid}/files/{path:path}",
+    responses={
+        200: {
+            "content": {
+                "application/octet-stream": {},
+            },
+        },
+    },
+    response_class=FileResponse,
+)
 def retrieve_job_files(
     path: str,
     job_dir: CurrentCompletedJobDir,
@@ -316,7 +326,14 @@ ArchiveFormats = Literal[".zip", ".tar", ".tar.xz", ".tar.gz", ".tar.bz2"]
 
 @router.get(
     "/{jobid}/archive",
-    responses={200: {"content": {"application/octet-stream": {}}}},
+    responses={
+        200: {
+            "content": {
+                "application/octet-stream": {},
+            },
+        },
+    },
+    response_class=FileResponse,
 )
 async def retrieve_job_directory_as_archive(
     job_dir: CurrentCompletedJobDir,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -276,6 +276,7 @@ def test_unroll_application_routes() -> None:
                     },
                     "type": "object",
                     "required": ["upload"],
+                    "title": "Upload app1",
                 },
                 "encoding": {
                     "upload": {
@@ -291,7 +292,7 @@ def test_unroll_application_routes() -> None:
             "/api/application/app1": {
                 "put": {
                     "tags": ["application"],
-                    "operationId": "app1",
+                    "operationId": "application_app1",
                     "summary": "Upload job to app1",
                     "requestBody": expected_request_body,
                     "responses": "mock responses",
@@ -337,14 +338,14 @@ def test_unroll_interactive_app_routes() -> None:
             "/api/job/{jobid}/interactive/iapp1": {
                 "post": {
                     "tags": ["interactive"],
-                    "operationId": "iapp1",
+                    "operationId": "interactive_application_iapp1",
                     "summary": "Run iapp1 interactive application",
                     "parameters": [
                         {
                             "name": "jobid",
                             "in": "path",
                             "required": True,
-                            "schema": {"type": "string"},
+                            "schema": {"type": "number"},
                         },
                     ],
                     "requestBody": {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,8 @@ from bartender.config import (
     InteractiveApplicationConfiguration,
     build_config,
     get_config,
+    unroll_application_routes,
+    unroll_interactive_app_routes,
 )
 from bartender.destinations import DestinationConfig
 from bartender.filesystems.local import LocalFileSystemConfig
@@ -227,3 +229,136 @@ class TestInteractiveApplicationConfiguration:
                 command_template=command_template,
                 input_schema=input_schema,
             )
+
+
+def test_unroll_application_routes() -> None:
+    openapi_schema = {
+        "paths": {
+            "/api/application/{application}": {
+                "put": {
+                    "responses": "mock responses",
+                    "security": "mock security",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JobDescription",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        "components": {
+            "schemas": {
+                "JobDescription": "mock JobDescription",
+            },
+        },
+    }
+    applications = {
+        "app1": ApplicatonConfiguration(command="echo", config="somefile"),
+    }
+
+    unroll_application_routes(openapi_schema, applications)
+
+    expected_request_body = {
+        "content": {
+            "multipart/form-data": {
+                "schema": {
+                    "properties": {
+                        "upload": {
+                            "type": "string",
+                            "format": "binary",
+                            "title": "Upload",
+                            "description": "Archive containing somefile file.",
+                        },
+                    },
+                    "type": "object",
+                    "required": ["upload"],
+                },
+                "encoding": {
+                    "upload": {
+                        "contentType": "application/zip, application/x-zip-compressed",
+                    },
+                },
+            },
+        },
+        "required": True,
+    }
+    expected = {
+        "paths": {
+            "/api/application/app1": {
+                "put": {
+                    "tags": ["application"],
+                    "operationId": "app1",
+                    "summary": "Upload job to app1",
+                    "requestBody": expected_request_body,
+                    "responses": "mock responses",
+                    "security": "mock security",
+                },
+            },
+        },
+        "components": {
+            "schemas": {},
+        },
+    }
+    assert openapi_schema == expected
+
+
+def test_unroll_interactive_app_routes() -> None:
+    openapi_schema = {
+        "paths": {
+            "/api/job/{jobid}/interactive/{application}": {
+                "post": {
+                    "responses": "mock responses",
+                    "security": "mock security",
+                },
+            },
+        },
+    }
+    input_schema = {
+        "type": "object",
+        "properties": {"message": {"type": "string"}},
+        "required": ["message"],
+    }
+
+    interactive_applications = {
+        "iapp1": InteractiveApplicationConfiguration(
+            command_template="echo {{ message }}",
+            input_schema=input_schema,
+        ),
+    }
+
+    unroll_interactive_app_routes(openapi_schema, interactive_applications)
+
+    expected = {
+        "paths": {
+            "/api/job/{jobid}/interactive/iapp1": {
+                "post": {
+                    "tags": ["interactive"],
+                    "operationId": "iapp1",
+                    "summary": "Run iapp1 interactive application",
+                    "parameters": [
+                        {
+                            "name": "jobid",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": input_schema,
+                            },
+                        },
+                    },
+                    "responses": "mock responses",
+                    "security": "mock security",
+                },
+            },
+        },
+    }
+    assert openapi_schema == expected

--- a/tests/web/test_application.py
+++ b/tests/web/test_application.py
@@ -12,35 +12,6 @@ from starlette import status
 
 
 @pytest.mark.anyio
-async def test_list_applications(
-    fastapi_app: FastAPI,
-    client: AsyncClient,
-) -> None:
-    url = fastapi_app.url_path_for("list_applications")
-    response = await client.get(url)
-    apps = response.json()
-    assert apps == ["app1"]
-
-
-@pytest.mark.anyio
-async def test_get_application(
-    fastapi_app: FastAPI,
-    client: AsyncClient,
-) -> None:
-    url = fastapi_app.url_path_for("get_application", application="app1")
-
-    response = await client.get(url)
-    app = response.json()
-
-    expected = {
-        "command": "wc $config",
-        "config": "job.ini",
-        "allowed_roles": [],
-    }
-    assert app == expected
-
-
-@pytest.mark.anyio
 async def test_upload(
     fastapi_app: FastAPI,
     client: AsyncClient,

--- a/tests/web/test_job.py
+++ b/tests/web/test_job.py
@@ -702,52 +702,6 @@ def demo_interactive_application(
 
 
 @pytest.mark.anyio
-async def test_list_interactive_apps(
-    fastapi_app: FastAPI,
-    client: AsyncClient,
-    auth_headers: Dict[str, str],
-    mock_ok_job: int,
-    demo_interactive_application: InteractiveApplicationConfiguration,
-) -> None:
-    job_id = str(mock_ok_job)
-    url = fastapi_app.url_path_for("list_interactive_apps", jobid=job_id)
-    response = await client.get(url, headers=auth_headers)
-
-    assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert result == ["wcm"]
-    assert response.headers["content-type"] == "application/json"
-
-
-@pytest.mark.anyio
-async def test_get_interactive_app(
-    fastapi_app: FastAPI,
-    client: AsyncClient,
-    auth_headers: Dict[str, str],
-    mock_ok_job: int,
-    demo_interactive_application: InteractiveApplicationConfiguration,
-) -> None:
-    job_id = str(mock_ok_job)
-    url = fastapi_app.url_path_for(
-        "get_interactive_app",
-        jobid=job_id,
-        application="wcm",
-    )
-    response = await client.get(url, headers=auth_headers)
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {
-        "command_template": "echo hello",
-        "input_schema": {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "type": "object",
-        },
-        "timeout": 10.0,
-    }
-    assert response.headers["content-type"] == "application/json"
-
-
-@pytest.mark.anyio
 async def test_run_interactive_app_invalid_jobapp(
     fastapi_app: FastAPI,
     client: AsyncClient,


### PR DESCRIPTION
Convert dynamic app routes to static in openapi spec.

![image](https://github.com/i-VRESSE/bartender/assets/1713488/9711ac38-c730-4bd0-bef3-895b074ff77f)

In generated client you get `ApplicationAPI.uploadHaddock3()` and `InteractiveApi.reclustfcc()`.

TODO
* [x] test in webapp
* [x] work with multiple applications